### PR TITLE
Add Home Assistant Operating System support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+docs/
+systemd/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 eda-modbus-bridge.iml
 node_modules
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+ENV LANG C.UTF-8
+
+WORKDIR /app
+
+COPY package.json package-lock.json /app/
+RUN apk add --no-cache nodejs npm python3 musl-dev make g++ linux-headers
+RUN npm i
+
+COPY config.json /app/config.json
+COPY entrypoint.sh /app/entrypoint.sh
+COPY app /app/app
+COPY eda-modbus-bridge.mjs /app/
+
+RUN chmod +x /app/entrypoint.sh
+
+CMD ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ ENV LANG C.UTF-8
 
 WORKDIR /app
 
-COPY package.json package-lock.json /app/
 RUN apk add --no-cache nodejs npm python3 musl-dev make g++ linux-headers
+
+COPY package.json package-lock.json /app/
 RUN npm i
 
 COPY config.json /app/config.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > I take no responsibility if you break your ventilation unit by using this software!
 
-An HTTP bridge for Enervent ventilation units with EDA automation (e.g. Pingvin). It provides a REST-ful HTTP interface 
+An HTTP/MQTT bridge for Enervent ventilation units with EDA automation (e.g. Pingvin). It provides a REST-ful HTTP interface 
 for interacting with the ventilation unit (reading temperatures and changing certain settings), as well as an MQTT 
 client which can publish readings regularly.
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,31 @@
+{
+  "name": "Enervent EDA Modbus Bridge",
+  "version": "1.0.0",
+  "slug": "hassos_eda_modbus_bridge",
+  "description": "An HTTP bridge for Enervent ventilation units with EDA automation",
+  "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
+  "url": "https://github.com/Jalle19/eda-modbus-bridge",
+  "startup": "services",
+  "boot": "auto",
+  "privileged": [
+    "SYS_MODULE",
+    "SYS_RAWIO"
+  ],
+  "devices": [
+    "/dev/bus/usb:/dev/bus/usb:rwm",
+    "/dev/mem:/dev/mem:rw"
+  ],
+  "auto_uart": true,
+  "options": {
+    "device": "/dev/ttyUSB0"
+  },
+  "schema": {
+    "device": "str"
+  },
+  "ports": {
+    "8080/tcp": 9090
+  },
+  "ports_description": {
+    "8080/tcp": "The HTTP listening port"
+  }
+}

--- a/config.json
+++ b/config.json
@@ -15,7 +15,7 @@
     "/dev/bus/usb:/dev/bus/usb:rwm",
     "/dev/mem:/dev/mem:rw"
   ],
-  "auto_uart": true,
+  "uart": true,
   "options": {
     "device": "/dev/ttyUSB0"
   },

--- a/config.json
+++ b/config.json
@@ -17,10 +17,12 @@
   ],
   "uart": true,
   "options": {
-    "device": "/dev/ttyUSB0"
+    "device": "/dev/ttyUSB0",
+    "extraOptions": ""
   },
   "schema": {
-    "device": "str"
+    "device": "str",
+    "extraOptions": "str"
   },
   "ports": {
     "8080/tcp": 9090

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "name": "Enervent EDA Modbus Bridge",
   "version": "1.0.0",
   "slug": "hassos_eda_modbus_bridge",
-  "description": "An HTTP bridge for Enervent ventilation units with EDA automation",
+  "description": "An HTTP/MQTT bridge for Enervent ventilation units with EDA automation",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "url": "https://github.com/Jalle19/eda-modbus-bridge",
   "startup": "services",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bashio
+
+DEVICE="$(bashio::config 'device')"
+
+ls -lh
+node /app/eda-modbus-bridge.mjs --device ${DEVICE} --httpPort 8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bashio
 
 DEVICE="$(bashio::config 'device')"
+EXTRA_OPTIONS="$(bashio::config 'extraOptions')"
 
-ls -lh
-node /app/eda-modbus-bridge.mjs --device ${DEVICE} --httpPort 8080
+node /app/eda-modbus-bridge.mjs --device ${DEVICE} ${EXTRA_OPTIONS}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eda-modbus-bridge",
   "version": "1.0.0",
-  "description": "An HTTP bridge for Enervent ventilation units with EDA automation",
+  "description": "An HTTP/MQTT bridge for Enervent ventilation units with EDA automation",
   "main": "eda-modbus-bridge.mjs",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
Only tested briefly (enough to make the daemon start and connect to
/dev/ttyUSB0)