### PR TITLE
Remove ventilation target setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Returns a JSON object like this:
         "ventilationLevelActual": 60
     },
     "settings": {
-        "ventilationLevelTarget": 75,
         "overPressureDelay": 60,
         "awayVentilationLevel": 30,
         "awayTemperatureReduction": 2,
@@ -119,15 +118,18 @@ The response is identical to that of `GET /mode/{flag}`.
 
 ### POST /setting/{setting}/{value}
 
-> Setting ventilation level doesn't seem to work, probably a firmware bug
+Changes the setting to the specified value. HTTP 400 is thrown if the value specified is out of range or invalid.
 
-Changes the setting to the specified value. Can be used to set the ventilation level and the target temperature. 
 Returns the new setting values, like this:
 
 ```json
 {
-  "ventilationLevelTarget": 60,
-  "temperatureTarget": 17.0
+   "overPressureDelay": 60,
+   "awayVentilationLevel": 30,
+   "awayTemperatureReduction": 2,
+   "longAwayVentilationLevel": 60,
+   "longAwayTemperatureReduction": 0,
+   "temperatureTarget": 17
 }
 ```
 

--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -189,10 +189,24 @@ export const getDeviceInformation = async (modbusClient) => {
     result = await mutex.runExclusive(async () => modbusClient.readHoldingRegisters(597, 3))
     deviceInformation = {
         ...deviceInformation,
-        'familyType': result.data[0],
+        'familyType': getDeviceFamilyName(result.data[0]),
         'serialNumber': result.data[1],
         'softwareVersion': result.data[2]
     }
 
     return deviceInformation
+}
+
+const getDeviceFamilyName = (familyTypeInt) => {
+    return [
+        'Pingvin',
+        'Pandion',
+        'Pelican',
+        'Pegasos',
+        'Pegasos XL',
+        'LTR-3',
+        'LTR-6̈́',
+        'LTR-7',
+        'LTR-7 XL'
+    ][familyTypeInt] ?? 'unknown'
 }

--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -11,7 +11,6 @@ const AVAILABLE_FLAGS = {
 }
 
 const AVAILABLE_SETTINGS = {
-    'ventilationLevel': 53,
     'overPressureDelay': 57,
     'awayVentilationLevel': 100,
     'awayTemperatureReduction': 101,
@@ -114,10 +113,9 @@ export const getReadings = async (modbusClient) => {
 }
 
 export const getSettings = async (modbusClient) => {
-    let result = await mutex.runExclusive(async () => modbusClient.readHoldingRegisters(53, 5))
+    let result = await mutex.runExclusive(async () => modbusClient.readHoldingRegisters(57, 1))
     let settings = {
-        'ventilationLevelTarget': result.data[0],
-        'overPressureDelay': result.data[4]
+        'overPressureDelay': result.data[0]
     }
 
     result = await mutex.runExclusive(async () => modbusClient.readHoldingRegisters(100, 4))
@@ -146,7 +144,6 @@ export const setSetting = async (modbusClient, setting, value) => {
     let intValue = parseInt(value, 10)
 
     switch (setting) {
-        case 'ventilationLevel':
         case 'awayVentilationLevel':
         case 'longAwayVentilationLevel':
             if (intValue < 20 || intValue > 100) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eda-modbus-bridge",
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
@@ -44,6 +43,7 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.7.tgz",
       "integrity": "sha512-cNWaxnEbbpLoSJ6GMb0ZeCpaciczm8XRE4jgBqe/BflWZb+wyiTYIocbsySxpS40WT3kJ0sNTFag77uSmQ6ftg==",
+      "hasInstallScript": true,
       "dependencies": {
         "@serialport/binding-abstract": "^9.0.7",
         "@serialport/parser-readline": "^9.0.7",


### PR DESCRIPTION
Closes #5

To dynamically change ventilation speed, the ventilation mode must be changed to e.g. "away". The settings for each mode can be configured in order to achieve the desired ventilation level.