### PR TITLE
Divide version value by 100 to get correct version

### DIFF
--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -192,7 +192,7 @@ export const getDeviceInformation = async (modbusClient) => {
         ...deviceInformation,
         'familyType': getDeviceFamilyName(result.data[0]),
         'serialNumber': result.data[1],
-        'softwareVersion': result.data[2]
+        'softwareVersion': result.data[2] / 100
     }
 
     return deviceInformation


### PR DESCRIPTION
Version number reported by summary is off by a multiplier of 100, lets divide it and get correct value out.