### PR TITLE
Add MQTT control and auto-discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Returns the new setting values, like this:
 The following topics are published to regularly
 
 ```
+eda/status
 eda/readings/freshAirTemperature
 eda/readings/supplyAirTemperatureAfterHeatRecovery
 eda/readings/supplyAirTemperature

--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -10,6 +10,16 @@ const AVAILABLE_FLAGS = {
     'summerNightCooling': 12,
 }
 
+// Modes that can only be true one at a time (mapped to their coil number)
+const MUTUALLY_EXCLUSIVE_MODES = {
+    'away': 1,
+    'longAway': 2,
+    'overPressure': 3,
+    'maxHeating': 6,
+    'maxCooling': 7,
+    'manualBoost': 10,
+}
+
 const AVAILABLE_SETTINGS = {
     'overPressureDelay': 57,
     'awayVentilationLevel': 100,
@@ -73,9 +83,8 @@ export const setFlag = async (modbusClient, flag, value) => {
 }
 
 const disableAllModesExcept = async (modbusClient, exceptedMode) => {
-    for (const mode in AVAILABLE_FLAGS) {
-        // summerNightCooling can be enabled simultaneously with other modes
-        if (mode === exceptedMode || mode === 'summerNightCooling') {
+    for (const mode in MUTUALLY_EXCLUSIVE_MODES) {
+        if (mode === exceptedMode) {
             continue
         }
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -177,26 +177,21 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
         'summerNightCooling': createSwitchConfiguration(configurationBase, 'summerNightCooling', 'Summer night cooling'),
     }
 
+    // Final map that describes everything we want to be auto-discovered
+    const configurationMap = {
+        'sensor': sensorConfigurationMap,
+        'number': numberConfigurationMap,
+        'switch': switchConfigurationMap,
+    }
+
     // Publish configurations
-    for (const [entityName, configuration] of Object.entries(sensorConfigurationMap)) {
-        const configurationTopicName = `homeassistant/sensor/${deviceIdentifier}/${entityName}/config`
+    for (const [entityType, entityConfigurationMap] of Object.entries(configurationMap)) {
+        for (const [entityName, configuration] of Object.entries(entityConfigurationMap)) {
+            const configurationTopicName = `homeassistant/${entityType}/${deviceIdentifier}/${entityName}/config`
 
-        console.log(`Publishing Home Assistant auto-discovery configuration for sensor "${entityName}"...`)
-        await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
-    }
-
-    for (const [entityName, configuration] of Object.entries(numberConfigurationMap)) {
-        const configurationTopicName = `homeassistant/number/${deviceIdentifier}/${entityName}/config`
-
-        console.log(`Publishing Home Assistant auto-discovery configuration for number "${entityName}"...`)
-        await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
-    }
-
-    for (const [entityName, configuration] of Object.entries(switchConfigurationMap)) {
-        const configurationTopicName = `homeassistant/switch/${deviceIdentifier}/${entityName}/config`
-
-        console.log(`Publishing Home Assistant auto-discovery configuration for switch "${entityName}"...`)
-        await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
+            console.log(`Publishing Home Assistant auto-discovery configuration for ${entityType} "${entityName}"...`)
+            await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
+        }
     }
 }
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -106,23 +106,18 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
         'device': mqttDeviceInformation,
     }
 
-    // Temperature sensors
-    const temperatureSensorConfigurationMap = {
+    // Sensor configuration
+    const sensorConfigurationMap = {
+        // Temperature sensors
         'freshAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'freshAirTemperature', 'Outside temperature',),
         'supplyAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'supplyAirTemperature', 'Supply air temperature'),
         'supplyAirTemperatureAfterHeatRecovery': createTemperatureSensorConfiguration(configurationBase, 'supplyAirTemperatureAfterHeatRecovery', 'Supply air temperature (after heat recovery)'),
         'exhaustAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'exhaustAirTemperature', 'Exhaust air temperature'),
         'wasteAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'wasteAirTemperature', 'Waste air temperature'),
-    }
-
-    // Humidity sensors
-    const humiditySensorConfigurationMap = {
+        // Humidity sensors
         'exhaustAirHumidity': createHumiditySensorConfiguration(configurationBase, 'exhaustAirHumidity', 'Exhaust air humidity'),
         'mean48HourExhaustHumidity': createHumiditySensorConfiguration(configurationBase, 'mean48HourExhaustHumidity', 'Exhaust air humidity (48h mean)'),
-    }
-
-    // Generic sensors (percentages, minutes left, cascade values)
-    const genericSensorConfigurationMap = {
+        // Generic sensors (percentages, minutes left, cascade values)
         'heatRecoverySupplySide': createGenericSensorConfiguration(configurationBase, 'heatRecoverySupplySide', 'Heat recovery (supply)', '%'),
         'heatRecoveryExhaustSide': createGenericSensorConfiguration(configurationBase, 'heatRecoveryExhaustSide', 'Heat recovery (exhaust)', '%'),
         'cascadeSp': createGenericSensorConfiguration(configurationBase, 'cascadeSp', 'Cascade setpoint'),
@@ -131,13 +126,6 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
         'overPressureTimeLeft': createGenericSensorConfiguration(configurationBase, 'overPressureTimeLeft', 'Overpressure time left', 'minutes'),
         'ventilationLevelTarget': createGenericSensorConfiguration(configurationBase, 'ventilationLevelTarget', 'Ventilation level (target)', '%'),
         'ventilationLevelActual': createGenericSensorConfiguration(configurationBase, 'ventilationLevelActual', 'Ventilation level (actual)', '%'),
-    }
-
-    // Configuration for each sensor
-    const sensorConfigurationMap = {
-        ...temperatureSensorConfigurationMap,
-        ...humiditySensorConfigurationMap,
-        ...genericSensorConfigurationMap,
     }
 
     // Configurable numbers

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -3,12 +3,16 @@ import {getReadings} from './modbus.mjs'
 const TOPIC_PREFIX = 'eda'
 
 export const getReadingsTopicValues = async (modbusClient) => {
+    // Always publish "online" to our status topic
+    let topicMap = {
+        [`${TOPIC_PREFIX}/status`]: 'online'
+    }
+
     const readings = await getReadings(modbusClient)
-    let topicMap = {}
 
     for (const [reading, value] of Object.entries(readings)) {
         const topicName = `${TOPIC_PREFIX}/readings/${reading}`
-        topicMap[topicName] = value
+        topicMap[topicName] = JSON.stringify(value)
     }
 
     return topicMap

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -1,11 +1,12 @@
 import { getReadings, getDeviceInformation, getSettings, setSetting, getFlagSummary, setFlag } from './modbus.mjs'
 
 const TOPIC_PREFIX = 'eda'
+const TOPIC_NAME_STATUS = `${TOPIC_PREFIX}/status`
 
 export const publishValues = async (modbusClient, mqttClient) => {
     // Create a map from topic name to value that should be published
     let topicMap = {
-        [`${TOPIC_PREFIX}/status`]: 'online',
+        [TOPIC_NAME_STATUS]: 'online',
     }
 
     // Publish state for each mode.
@@ -102,7 +103,7 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
 
     const configurationBase = {
         'platform': 'mqtt',
-        'availability_topic': `${TOPIC_PREFIX}/status`,
+        'availability_topic': TOPIC_NAME_STATUS,
         'device': mqttDeviceInformation,
     }
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -1,4 +1,4 @@
-import { getReadings, getDeviceInformation } from './modbus.mjs'
+import { getReadings, getDeviceInformation, getSettings } from './modbus.mjs'
 
 const TOPIC_PREFIX = 'eda'
 
@@ -8,11 +8,19 @@ export const publishReadings = async (modbusClient, mqttClient) => {
         [`${TOPIC_PREFIX}/status`]: 'online',
     }
 
-    // Publish each reading to a separate topic
+    // Publish each reading
     const readings = await getReadings(modbusClient)
 
     for (const [reading, value] of Object.entries(readings)) {
         const topicName = `${TOPIC_PREFIX}/readings/${reading}`
+        topicMap[topicName] = JSON.stringify(value)
+    }
+
+    // Publish each setting
+    const settings = await getSettings(modbusClient)
+
+    for (const [setting, value] of Object.entries(settings)) {
+        const topicName = `${TOPIC_PREFIX}/settings/${setting}`
         topicMap[topicName] = JSON.stringify(value)
     }
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -1,4 +1,4 @@
-import { getReadings, getDeviceInformation, getSettings } from './modbus.mjs'
+import { getReadings, getDeviceInformation, getSettings, setSetting } from './modbus.mjs'
 
 const TOPIC_PREFIX = 'eda'
 
@@ -31,6 +31,27 @@ export const publishReadings = async (modbusClient, mqttClient) => {
     }
 
     await Promise.all(publishPromises)
+}
+
+export const subscribeToSettingChanges = async (modbusClient, mqttClient) => {
+    const topicName = `${TOPIC_PREFIX}/settings/+/set`
+
+    console.log(`Subscribing to topic(s) ${topicName}`)
+
+    await mqttClient.subscribe(topicName)
+}
+
+export const handleMessage = async (modbusClient, topicName, payload) => {
+    console.log(`Received ${payload} on topic ${topicName}`)
+
+    // Handle settings updates
+    if (topicName.startsWith('eda/settings/') && topicName.endsWith('/set')) {
+        const settingName = topicName.substring('eda/settings/'.length, topicName.lastIndexOf('/'))
+
+        console.log(`Updating setting ${settingName} to ${payload}`)
+
+        await setSetting(modbusClient, settingName, payload)
+    }
 }
 
 export const configureMqttDiscovery = async (modbusClient, mqttClient) => {

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -1,4 +1,4 @@
-import {getReadings} from './modbus.mjs'
+import { getReadings, getDeviceInformation } from './modbus.mjs'
 
 const TOPIC_PREFIX = 'eda'
 
@@ -23,4 +23,109 @@ export const publishReadings = async (modbusClient, mqttClient) => {
     }
 
     await Promise.all(publishPromises)
+}
+
+export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
+    const modbusDeviceInformation = await getDeviceInformation(modbusClient)
+    const familyType = modbusDeviceInformation.familyType
+    const serialNumber = modbusDeviceInformation.serialNumber
+    const softwareVersion = modbusDeviceInformation.softwareVersion
+    const deviceIdentifier = `Enervent-${familyType}-${serialNumber}-${softwareVersion}`;
+
+    // The "device" object that is part of each sensor's configuration payload
+    const mqttDeviceInformation = {
+        'identifiers': deviceIdentifier,
+        'name': `Enervent ${familyType}`,
+        'sw_version': softwareVersion,
+        'model': familyType,
+        'manufacturer': 'Enervent',
+    }
+
+    const configurationBase = {
+        'platform': 'mqtt',
+        'availability_topic': `${TOPIC_PREFIX}/status`,
+        'device': mqttDeviceInformation,
+    }
+
+    // Temperature sensors
+    const temperatureSensorConfigurationMap = {
+        'freshAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'freshAirTemperature', 'Outside temperature',),
+        'supplyAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'supplyAirTemperature', 'Supply air temperature'),
+        'supplyAirTemperatureAfterHeatRecovery': createTemperatureSensorConfiguration(configurationBase, 'supplyAirTemperatureAfterHeatRecovery', 'Supply air temperature (after heat recovery)'),
+        'exhaustAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'exhaustAirTemperature', 'Exhaust air temperature'),
+        'wasteAirTemperature': createTemperatureSensorConfiguration(configurationBase, 'wasteAirTemperature', 'Waste air temperature'),
+    }
+
+    // Humidity sensors
+    const humiditySensorConfigurationMap = {
+        'exhaustAirHumidity': createHumiditySensorConfiguration(configurationBase, 'exhaustAirHumidity', 'Exhaust air humidity'),
+        'mean48HourExhaustHumidity': createHumiditySensorConfiguration(configurationBase, 'mean48HourExhaustHumidity', 'Exhaust air humidity (48h mean)'),
+    }
+
+    // Generic sensors (percentages, minutes left, cascade values)
+    const genericSensorConfigurationMap = {
+        'heatRecoverySupplySide': createGenericSensorConfiguration(configurationBase, 'heatRecoverySupplySide', 'Heat recovery (supply)', '%'),
+        'heatRecoveryExhaustSide': createGenericSensorConfiguration(configurationBase, 'heatRecoveryExhaustSide', 'Heat recovery (exhaust)', '%'),
+        'cascadeSp': createGenericSensorConfiguration(configurationBase, 'cascadeSp', 'Cascade setpoint'),
+        'cascadeP': createGenericSensorConfiguration(configurationBase, 'cascadeP', 'Cascade P-value'),
+        'cascadeI': createGenericSensorConfiguration(configurationBase, 'cascadeI', 'Cascade I-value'),
+        'overPressureTimeLeft': createGenericSensorConfiguration(configurationBase, 'overPressureTimeLeft', 'Overpressure time left', 'minutes'),
+        'ventilationLevelTarget': createGenericSensorConfiguration(configurationBase, 'ventilationLevelTarget', 'Ventilation level (target)', '%'),
+        'ventilationLevelActual': createGenericSensorConfiguration(configurationBase, 'ventilationLevelActual', 'Ventilation level (actual)', '%'),
+    }
+
+    // Configuration for each entity
+    const entityConfigurationMap = {
+        ...temperatureSensorConfigurationMap,
+        ...humiditySensorConfigurationMap,
+        ...genericSensorConfigurationMap,
+    }
+
+    // Publish configurations
+    for (const [entityName, configuration] of Object.entries(entityConfigurationMap)) {
+        const configurationTopicName = `homeassistant/sensor/${deviceIdentifier}/${entityName}/config`
+
+        console.log(`Publishing Home Assistant auto-discovery configuration for "${entityName}"...`)
+        await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
+    }
+}
+
+const createTemperatureSensorConfiguration = (configurationBase, readingName, entityName) => {
+    return {
+        ...configurationBase,
+        'device_class': 'temperature',
+        'unit_of_measurement': '°C',
+        'state_class': 'measurement',
+        'name': entityName,
+        'state_topic': `${TOPIC_PREFIX}/readings/${readingName}`,
+        'unique_id': `eda-${readingName}`
+    }
+}
+
+const createHumiditySensorConfiguration = (configurationBase, readingName, entityName) => {
+    return {
+        ...configurationBase,
+        'device_class': 'humidity',
+        'unit_of_measurement': '%H',
+        'state_class': 'measurement',
+        'name': entityName,
+        'state_topic': `${TOPIC_PREFIX}/readings/${readingName}`,
+        'unique_id': `eda-${readingName}`
+    }
+}
+
+const createGenericSensorConfiguration = (configurationBase, readingName, entityName, unit) => {
+    const configuration = {
+        ...configurationBase,
+        'state_class': 'measurement',
+        'name': entityName,
+        'state_topic': `${TOPIC_PREFIX}/readings/${readingName}`,
+        'unique_id': `eda-${readingName}`
+    }
+
+    if (unit) {
+        configuration['unit_of_measurement'] = unit
+    }
+
+    return configuration;
 }

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -58,7 +58,7 @@ export const subscribeToSettingChanges = async (modbusClient, mqttClient) => {
     }
 }
 
-export const handleMessage = async (modbusClient, topicName, payload) => {
+export const handleMessage = async (modbusClient, mqttClient, topicName, payload) => {
     // Payload looks like a string when logged, but any comparison with === will equal false unless we convert the
     // Buffer to a string
     const payloadString = payload.toString()
@@ -79,6 +79,9 @@ export const handleMessage = async (modbusClient, topicName, payload) => {
 
         await setFlag(modbusClient, mode, payloadString === 'ON')
     }
+
+    // Publish all values again for state changes to "take"
+    await publishValues(modbusClient, mqttClient)
 }
 
 export const configureMqttDiscovery = async (modbusClient, mqttClient) => {

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -2,7 +2,7 @@ import { getReadings, getDeviceInformation, getSettings, setSetting } from './mo
 
 const TOPIC_PREFIX = 'eda'
 
-export const publishReadings = async (modbusClient, mqttClient) => {
+export const publishValues = async (modbusClient, mqttClient) => {
     // Create a map from topic name to value that should be published
     let topicMap = {
         [`${TOPIC_PREFIX}/status`]: 'online',

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -44,8 +44,8 @@ export const publishValues = async (modbusClient, mqttClient) => {
     await Promise.all(publishPromises)
 }
 
-export const subscribeToSettingChanges = async (modbusClient, mqttClient) => {
-    // Subscribe to both settings and mode changes
+export const subscribeToChanges = async (modbusClient, mqttClient) => {
+    // Subscribe to settings and mode changes
     const topicNames = [
         `${TOPIC_PREFIX}/mode/+/set`,
         `${TOPIC_PREFIX}/settings/+/set`,

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -91,7 +91,7 @@ const argv = yargs(process.argv.slice(2))
                 const publishPromises = []
 
                 for (const [topic, value] of Object.entries(topicMap)) {
-                    publishPromises.push(mqttClient.publish(topic, JSON.stringify(value)))
+                    publishPromises.push(mqttClient.publish(topic, value))
                 }
 
                 await Promise.all(publishPromises)

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -4,7 +4,7 @@ import MQTT from 'async-mqtt'
 import yargs from 'yargs'
 import ModbusRTU from 'modbus-serial'
 import { getFlagStatus, root, setFlagStatus, setSetting, summary } from './app/handlers.mjs'
-import { publishValues, configureMqttDiscovery, subscribeToSettingChanges, handleMessage } from './app/mqtt.mjs'
+import { publishValues, configureMqttDiscovery, subscribeToChanges, handleMessage } from './app/mqtt.mjs'
 
 const argv = yargs(process.argv.slice(2))
     .usage('node $0 [options]')
@@ -92,8 +92,8 @@ const argv = yargs(process.argv.slice(2))
 
             console.log(`MQTT scheduler started, will publish readings every ${argv.mqttPublishInterval} seconds`)
 
-            // Subscribe to setting changes and register a handler
-            await subscribeToSettingChanges(modbusClient, mqttClient)
+            // Subscribe to changes and register a handler
+            await subscribeToChanges(modbusClient, mqttClient)
             mqttClient.on('message', async (topicName, payload) => {
                 await handleMessage(modbusClient, mqttClient, topicName, payload)
             })

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -95,7 +95,7 @@ const argv = yargs(process.argv.slice(2))
             // Subscribe to setting changes and register a handler
             await subscribeToSettingChanges(modbusClient, mqttClient)
             mqttClient.on('message', async (topicName, payload) => {
-                await handleMessage(modbusClient, topicName, payload)
+                await handleMessage(modbusClient, mqttClient, topicName, payload)
             })
 
             // Configure Home Assistant MQTT discovery

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -4,7 +4,7 @@ import MQTT from 'async-mqtt'
 import yargs from 'yargs'
 import ModbusRTU from 'modbus-serial'
 import { getFlagStatus, root, setFlagStatus, setSetting, summary } from './app/handlers.mjs'
-import { publishReadings, configureMqttDiscovery, subscribeToSettingChanges, handleMessage } from './app/mqtt.mjs'
+import { publishValues, configureMqttDiscovery, subscribeToSettingChanges, handleMessage } from './app/mqtt.mjs'
 
 const argv = yargs(process.argv.slice(2))
     .usage('node $0 [options]')
@@ -85,9 +85,9 @@ const argv = yargs(process.argv.slice(2))
         try {
             const mqttClient = await MQTT.connectAsync(argv.mqttBrokerUrl)
 
-            // Publish readings regularly
+            // Publish readings/settings/modes regularly
             setInterval(async () => {
-                await publishReadings(modbusClient, mqttClient)
+                await publishValues(modbusClient, mqttClient)
             }, argv.mqttPublishInterval * 1000)
 
             console.log(`MQTT scheduler started, will publish readings every ${argv.mqttPublishInterval} seconds`)

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -4,7 +4,7 @@ import MQTT from 'async-mqtt'
 import yargs from 'yargs'
 import ModbusRTU from 'modbus-serial'
 import { getFlagStatus, root, setFlagStatus, setSetting, summary } from './app/handlers.mjs'
-import { publishReadings } from './app/mqtt.mjs'
+import { publishReadings, configureMqttDiscovery } from './app/mqtt.mjs'
 
 const argv = yargs(process.argv.slice(2))
     .usage('node $0 [options]')
@@ -89,6 +89,12 @@ const argv = yargs(process.argv.slice(2))
             setInterval(async () => {
                 await publishReadings(modbusClient, mqttClient)
             }, argv.mqttPublishInterval * 1000)
+
+            console.log(`MQTT scheduler started, will publish readings every ${argv.mqttPublishInterval} seconds`)
+
+            // Configure Home Assistant MQTT discovery
+            await configureMqttDiscovery(modbusClient, mqttClient)
+            console.log('Finished configuration Home Assistant MQTT discovery')
         } catch (e) {
             console.error(`Failed to connect to MQTT broker: ${e.message}`)
         }

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -4,7 +4,7 @@ import MQTT from 'async-mqtt'
 import yargs from 'yargs'
 import ModbusRTU from 'modbus-serial'
 import { getFlagStatus, root, setFlagStatus, setSetting, summary } from './app/handlers.mjs'
-import { publishReadings, configureMqttDiscovery } from './app/mqtt.mjs'
+import { publishReadings, configureMqttDiscovery, subscribeToSettingChanges, handleMessage } from './app/mqtt.mjs'
 
 const argv = yargs(process.argv.slice(2))
     .usage('node $0 [options]')
@@ -91,6 +91,12 @@ const argv = yargs(process.argv.slice(2))
             }, argv.mqttPublishInterval * 1000)
 
             console.log(`MQTT scheduler started, will publish readings every ${argv.mqttPublishInterval} seconds`)
+
+            // Subscribe to setting changes and register a handler
+            await subscribeToSettingChanges(modbusClient, mqttClient)
+            mqttClient.on('message', async (topicName, payload) => {
+                await handleMessage(modbusClient, topicName, payload)
+            })
 
             // Configure Home Assistant MQTT discovery
             await configureMqttDiscovery(modbusClient, mqttClient)


### PR DESCRIPTION
* add Home Assistant MQTT discovery support
  - sensors
  - switches (for ventilation modes)
  - numbers (for configuration)
* settings are also published to MQTT now (not just readings)
* settings and modes can now be changed via MQTT as well
* make sure only one mode is active at the same time (handled transparently on the Modbus level)

TODO:

* README updates and documentation
* Better device identifier perhaps?
* ~MQTT publish when settings are changed via HTTP~ IMO not worth since changes on the control panel aren't reflected immediately either. Discrepancy will last for a maximum of $updateInterval seconds anyway.
* Make Home Assistant auto-discovery optional (for standalone setups)

@tomrosenback can you give this a spin? Assuming you have MQTT in your environment?