### PR TITLE
Use "retain" when publishing MQTT discovery configuration messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## future release
 
 * add basic test suite
+* retain MQTT discovery configuration messages (fixes https://github.com/Jalle19/eda-modbus-bridge/issues/29)
 
 ## 2.0.0
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -207,8 +207,11 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
         for (const [entityName, configuration] of Object.entries(entityConfigurationMap)) {
             const configurationTopicName = `homeassistant/${entityType}/${deviceIdentifier}/${entityName}/config`
 
+            // "retain" is used so that the entities will be available immediately after a Home Assistant restart
             console.log(`Publishing Home Assistant auto-discovery configuration for ${entityType} "${entityName}"...`)
-            await mqttClient.publish(configurationTopicName, JSON.stringify(configuration))
+            await mqttClient.publish(configurationTopicName, JSON.stringify(configuration), {
+                retain: true,
+            })
         }
     }
 }


### PR DESCRIPTION
Fixes #29