### PR TITLE
Set correct humidity unit to remove log error

### DIFF
--- a/app/homeassistant.mjs
+++ b/app/homeassistant.mjs
@@ -246,7 +246,7 @@ const createTemperatureSensorConfiguration = (configurationBase, readingName, en
 const createHumiditySensorConfiguration = (configurationBase, readingName, entityName) => {
     return createSensorConfiguration(configurationBase, readingName, entityName, {
         'device_class': 'humidity',
-        'unit_of_measurement': '%H',
+        'unit_of_measurement': '%',
     })
 }
 


### PR DESCRIPTION
Noted that Home Assistant complains about incorrect unit for humidity device class, so corrected it to % instead of %H.