### PR TITLE
Log the stack trace when catching unknown exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## future release
 
+* Log stack traces for unknown errors (should help debug https://github.com/Jalle19/home-assistant-addon-repository/issues/17)
 * Use `%` instead of `%H` for MQTT humidity sensor entities (https://github.com/Jalle19/eda-modbus-bridge/issues/64)
 * Fix automatic reconnect to MQTT broker when initial connection attempt fails (https://github.com/Jalle19/eda-modbus-bridge/issues/61)
 

--- a/eda-modbus-bridge.mjs
+++ b/eda-modbus-bridge.mjs
@@ -165,6 +165,8 @@ const argv = yargs(process.argv.slice(2))
             mqttClient.on('reconnect', () => {
                 console.log(`Attempting to reconnect to ${argv.mqttBrokerUrl}`)
             })
-        } catch (e) {}
+        } catch (e) {
+            console.error(`Unknown exception occurred: ${e.message}`, e.stack)
+        }
     }
 })()


### PR DESCRIPTION
Should help debug whether the "Timed out" messages reported in https://github.com/Jalle19/home-assistant-addon-repository/issues/17 are from the MQTT client or the Modbus client