### PR TITLE
Add rudimentary validation of the MQTT broker URL

### DIFF
--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -149,6 +149,10 @@ export const handleMessage = async (modbusClient, mqttClient, topicName, payload
     }
 }
 
+export const validateBrokerUrl = (brokerUrl) => {
+    return brokerUrl.startsWith('tcp://')
+}
+
 const createBinaryValue = (value) => {
     // Boolean values are exposed as "ON" and "OFF" respectively since those are the
     // defaults for MQTT binary sensors in Home Assistant

--- a/tests/mqtt.test.mjs
+++ b/tests/mqtt.test.mjs
@@ -1,0 +1,8 @@
+import { validateBrokerUrl } from '../app/mqtt.mjs'
+
+test('validateMqttUrl', () => {
+    expect(validateBrokerUrl('tcp://localhost:1883')).toEqual(true)
+    expect(validateBrokerUrl('tcp://localhost')).toEqual(true)
+    expect(validateBrokerUrl('localhost:1883')).toEqual(false)
+    expect(validateBrokerUrl('localhost')).toEqual(false)
+})


### PR DESCRIPTION
A user reported having problems with MQTT and it turned out it wasn't completely obvious that the URL needs to start with `tcp://`