### PR TITLE
Bump serialport to 11.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x, 16.x, 18.x ]
+        node-version: [ 14.x, 16.x, 18.x ]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://www.home-assistant.io/integrations/switch.rest/ with minimal effort. See
 
 ## Requirements
 
-* Node.js 12.x or newer
+* Node.js 14.x or newer
 * An Enervent ventilation unit with EDA or MD automation (Pingvin, Pandion and LTR-3 confirmed working)
 * An RS-485 device (e.g. `/dev/ttyUSB0`) connected to the Enervent unit's Freeway port (see 
   [docs/CONNECTION.md](./docs/CONNECTION.md) for details on how to connect to the unit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.18.2",
         "express-winston": "^4.2.0",
         "modbus-serial": "^8.0.11",
+        "serialport": "^11.0.1",
         "winston": "^3.10.0",
         "yargs": "^16.2.0"
       },
@@ -1063,19 +1064,44 @@
       }
     },
     "node_modules/@serialport/bindings-cpp": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
-      "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-11.0.3.tgz",
+      "integrity": "sha512-xgNDJ7pHHZCJMoDsEH+D8q5CV+V3RGN4/jLEG9SQ7q6kh+o03axV0l/upPHZ0HW4tTXpGgqPIGbXOTrD4RGQQA==",
       "hasInstallScript": true,
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
-        "@serialport/parser-readline": "^10.2.1",
-        "debug": "^4.3.2",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.3.0"
+        "@serialport/parser-readline": "11.0.0",
+        "debug": "4.3.4",
+        "node-addon-api": "6.1.0",
+        "node-gyp-build": "4.6.0"
       },
       "engines": {
-        "node": ">=12.17.0 <13.0 || >=14.0.0"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.0.tgz",
+      "integrity": "sha512-aZLJhlRTjSmEwllLG7S4J8s8ctRAS0cbvCpO87smLvl3e4BgzbVgF6Z6zaJd3Aji2uSiYgfedCdNc4L6W+1E2g==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.0.tgz",
+      "integrity": "sha512-rRAivhRkT3YO28WjmmG4FQX6L+KMb5/ikhyylRfzWPw0nSXy97+u07peS9CbHqaNvJkMhH1locp2H36aGMOEIA==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "11.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
@@ -1090,9 +1116,9 @@
       }
     },
     "node_modules/@serialport/parser-byte-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-      "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-11.0.1.tgz",
+      "integrity": "sha512-UsffR5b3NHwhjJzsWv5fZMkoq3wGNyUcRTA9jlu02w+2kMlBRJPzlPVB5szVX0VWUEqkCg+3VaU2XWuYr+uAUA==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1101,9 +1127,9 @@
       }
     },
     "node_modules/@serialport/parser-cctalk": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-      "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-11.0.1.tgz",
+      "integrity": "sha512-klzVQfRcC1m0SVDV2Dy9hHfwweO2/mUMUyuXK04FRkKHy5/AdETmk9KTVVVVfpDCSysvHoyQPwiDFq8ddwX3cQ==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1112,9 +1138,9 @@
       }
     },
     "node_modules/@serialport/parser-delimiter": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-      "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.1.tgz",
+      "integrity": "sha512-NAsYa3OFt2xEnj/+0BRkQP2qkRNbXBPEq6uFJEdNdzcTSF+BTRXkoIRrWBq3N6koovPqW6lnbxc/iJYe5AX/2Q==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1123,9 +1149,9 @@
       }
     },
     "node_modules/@serialport/parser-inter-byte-timeout": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-      "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-11.0.1.tgz",
+      "integrity": "sha512-PEFV9dSpW+ptH1rLhdB9KgE+rbJ/FvQiZz0mx+4jkv/Po4g3PNsEEMXfMW0aQVSFVsmitvmE0jHlhGjLv8GQEg==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1134,19 +1160,19 @@
       }
     },
     "node_modules/@serialport/parser-packet-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-      "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-11.0.1.tgz",
+      "integrity": "sha512-KwPu8dsAI+eN4fnUS1vVmrOpUtBK4p9L9cHhwn5ZmfcvwvZMHp/J+IEu7xH0g5aM1/8QEoaql26BQP+sZ71NQQ==",
       "engines": {
         "node": ">=8.6.0"
       }
     },
     "node_modules/@serialport/parser-readline": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-      "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.1.tgz",
+      "integrity": "sha512-wkJ3EI733+yhbi7eBWzs/qn8+cfIBcYQjfrILPNqslAy6VlgdKw+pHoblDFmg78GN0TqGUDSWlTJ65oLEPVp5Q==",
       "dependencies": {
-        "@serialport/parser-delimiter": "10.5.0"
+        "@serialport/parser-delimiter": "11.0.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1156,9 +1182,9 @@
       }
     },
     "node_modules/@serialport/parser-ready": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-      "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-11.0.1.tgz",
+      "integrity": "sha512-v/bvlgKhrNt+SVLSqlfXCO1HEinfRRMGnzqbpdVCgu2SiWIEenCLjs51JisKVYQoQFcXdP/EHZnzm7NPXHDlAg==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1167,9 +1193,9 @@
       }
     },
     "node_modules/@serialport/parser-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-      "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-11.0.1.tgz",
+      "integrity": "sha512-Lf3k7qibYqZ0+/wX3UA8fRng3WtQ+UyLpjQhG1COs6OBSq5/I5tYXczfhlrbA0gHo1qzgzr2V2t7m6FoBSc81Q==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1178,9 +1204,9 @@
       }
     },
     "node_modules/@serialport/parser-slip-encoder": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-      "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-11.0.1.tgz",
+      "integrity": "sha512-l4mXsAGzpmPO7+uqKJqtPDW643irfnGEWbiy34FoYvuOs8n0SmiMtgQZFAtvlTNQCRWE2tykF/WG6K/McJthDw==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1189,9 +1215,9 @@
       }
     },
     "node_modules/@serialport/parser-spacepacket": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-      "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-11.0.1.tgz",
+      "integrity": "sha512-Lq7fXoOsLOMo4XEt9HB31zV5LhrteXlsOy2o6r39TfRwU6x8Nou9jQMA9vW0a6yPra5zwsHIaNrA6tDOGj2Ozg==",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1200,12 +1226,12 @@
       }
     },
     "node_modules/@serialport/stream": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
-      "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-11.0.1.tgz",
+      "integrity": "sha512-6pjyKRg8MQuvhGfg36+PF7K5eGNQcEswCSiAg1UPilqqFS8X1QnaiSCn5UFp/hCN+pAtlFjkOi0ztvtmSI7n4g==",
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
-        "debug": "^4.3.2"
+        "debug": "4.3.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5244,6 +5270,182 @@
         "serialport": "^10.4.0"
       }
     },
+    "node_modules/modbus-serial/node_modules/@serialport/bindings-cpp": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
+      "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "@serialport/parser-readline": "^10.2.1",
+        "debug": "^4.3.2",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12.17.0 <13.0 || >=14.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-byte-length": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
+      "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-cctalk": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
+      "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-delimiter": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
+      "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-inter-byte-timeout": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
+      "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-packet-length": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
+      "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-readline": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
+      "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "10.5.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-ready": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
+      "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
+      "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-slip-encoder": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
+      "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/parser-spacepacket": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
+      "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/@serialport/stream": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
+      "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/modbus-serial/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/modbus-serial/node_modules/serialport": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
+      "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "10.8.0",
+        "@serialport/parser-byte-length": "10.5.0",
+        "@serialport/parser-cctalk": "10.5.0",
+        "@serialport/parser-delimiter": "10.5.0",
+        "@serialport/parser-inter-byte-timeout": "10.5.0",
+        "@serialport/parser-packet-length": "10.5.0",
+        "@serialport/parser-readline": "10.5.0",
+        "@serialport/parser-ready": "10.5.0",
+        "@serialport/parser-regex": "10.5.0",
+        "@serialport/parser-slip-encoder": "10.5.0",
+        "@serialport/parser-spacepacket": "10.5.0",
+        "@serialport/stream": "10.5.0",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
     "node_modules/mqtt": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
@@ -5306,9 +5508,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
@@ -6077,24 +6279,24 @@
       }
     },
     "node_modules/serialport": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
-      "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-11.0.1.tgz",
+      "integrity": "sha512-j/ntDuewAkqL6g5wKjwV2RTyLBL9cpob8aRd3yLAViYApTsJoYqRleyuzst0OboNTBjBsoxQ4YKYhuYHi1XViQ==",
       "dependencies": {
         "@serialport/binding-mock": "10.2.2",
-        "@serialport/bindings-cpp": "10.8.0",
-        "@serialport/parser-byte-length": "10.5.0",
-        "@serialport/parser-cctalk": "10.5.0",
-        "@serialport/parser-delimiter": "10.5.0",
-        "@serialport/parser-inter-byte-timeout": "10.5.0",
-        "@serialport/parser-packet-length": "10.5.0",
-        "@serialport/parser-readline": "10.5.0",
-        "@serialport/parser-ready": "10.5.0",
-        "@serialport/parser-regex": "10.5.0",
-        "@serialport/parser-slip-encoder": "10.5.0",
-        "@serialport/parser-spacepacket": "10.5.0",
-        "@serialport/stream": "10.5.0",
-        "debug": "^4.3.3"
+        "@serialport/bindings-cpp": "11.0.3",
+        "@serialport/parser-byte-length": "11.0.1",
+        "@serialport/parser-cctalk": "11.0.1",
+        "@serialport/parser-delimiter": "11.0.1",
+        "@serialport/parser-inter-byte-timeout": "11.0.1",
+        "@serialport/parser-packet-length": "11.0.1",
+        "@serialport/parser-readline": "11.0.1",
+        "@serialport/parser-ready": "11.0.1",
+        "@serialport/parser-regex": "11.0.1",
+        "@serialport/parser-slip-encoder": "11.0.1",
+        "@serialport/parser-spacepacket": "11.0.1",
+        "@serialport/stream": "11.0.1",
+        "debug": "4.3.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7855,15 +8057,30 @@
       }
     },
     "@serialport/bindings-cpp": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
-      "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-11.0.3.tgz",
+      "integrity": "sha512-xgNDJ7pHHZCJMoDsEH+D8q5CV+V3RGN4/jLEG9SQ7q6kh+o03axV0l/upPHZ0HW4tTXpGgqPIGbXOTrD4RGQQA==",
       "requires": {
         "@serialport/bindings-interface": "1.2.2",
-        "@serialport/parser-readline": "^10.2.1",
-        "debug": "^4.3.2",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.3.0"
+        "@serialport/parser-readline": "11.0.0",
+        "debug": "4.3.4",
+        "node-addon-api": "6.1.0",
+        "node-gyp-build": "4.6.0"
+      },
+      "dependencies": {
+        "@serialport/parser-delimiter": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.0.tgz",
+          "integrity": "sha512-aZLJhlRTjSmEwllLG7S4J8s8ctRAS0cbvCpO87smLvl3e4BgzbVgF6Z6zaJd3Aji2uSiYgfedCdNc4L6W+1E2g=="
+        },
+        "@serialport/parser-readline": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.0.tgz",
+          "integrity": "sha512-rRAivhRkT3YO28WjmmG4FQX6L+KMb5/ikhyylRfzWPw0nSXy97+u07peS9CbHqaNvJkMhH1locp2H36aGMOEIA==",
+          "requires": {
+            "@serialport/parser-delimiter": "11.0.0"
+          }
+        }
       }
     },
     "@serialport/bindings-interface": {
@@ -7872,65 +8089,65 @@
       "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
     },
     "@serialport/parser-byte-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-      "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-11.0.1.tgz",
+      "integrity": "sha512-UsffR5b3NHwhjJzsWv5fZMkoq3wGNyUcRTA9jlu02w+2kMlBRJPzlPVB5szVX0VWUEqkCg+3VaU2XWuYr+uAUA=="
     },
     "@serialport/parser-cctalk": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-      "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-11.0.1.tgz",
+      "integrity": "sha512-klzVQfRcC1m0SVDV2Dy9hHfwweO2/mUMUyuXK04FRkKHy5/AdETmk9KTVVVVfpDCSysvHoyQPwiDFq8ddwX3cQ=="
     },
     "@serialport/parser-delimiter": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-      "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.1.tgz",
+      "integrity": "sha512-NAsYa3OFt2xEnj/+0BRkQP2qkRNbXBPEq6uFJEdNdzcTSF+BTRXkoIRrWBq3N6koovPqW6lnbxc/iJYe5AX/2Q=="
     },
     "@serialport/parser-inter-byte-timeout": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-      "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-11.0.1.tgz",
+      "integrity": "sha512-PEFV9dSpW+ptH1rLhdB9KgE+rbJ/FvQiZz0mx+4jkv/Po4g3PNsEEMXfMW0aQVSFVsmitvmE0jHlhGjLv8GQEg=="
     },
     "@serialport/parser-packet-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-      "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-11.0.1.tgz",
+      "integrity": "sha512-KwPu8dsAI+eN4fnUS1vVmrOpUtBK4p9L9cHhwn5ZmfcvwvZMHp/J+IEu7xH0g5aM1/8QEoaql26BQP+sZ71NQQ=="
     },
     "@serialport/parser-readline": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-      "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.1.tgz",
+      "integrity": "sha512-wkJ3EI733+yhbi7eBWzs/qn8+cfIBcYQjfrILPNqslAy6VlgdKw+pHoblDFmg78GN0TqGUDSWlTJ65oLEPVp5Q==",
       "requires": {
-        "@serialport/parser-delimiter": "10.5.0"
+        "@serialport/parser-delimiter": "11.0.1"
       }
     },
     "@serialport/parser-ready": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-      "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-11.0.1.tgz",
+      "integrity": "sha512-v/bvlgKhrNt+SVLSqlfXCO1HEinfRRMGnzqbpdVCgu2SiWIEenCLjs51JisKVYQoQFcXdP/EHZnzm7NPXHDlAg=="
     },
     "@serialport/parser-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-      "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-11.0.1.tgz",
+      "integrity": "sha512-Lf3k7qibYqZ0+/wX3UA8fRng3WtQ+UyLpjQhG1COs6OBSq5/I5tYXczfhlrbA0gHo1qzgzr2V2t7m6FoBSc81Q=="
     },
     "@serialport/parser-slip-encoder": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-      "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-11.0.1.tgz",
+      "integrity": "sha512-l4mXsAGzpmPO7+uqKJqtPDW643irfnGEWbiy34FoYvuOs8n0SmiMtgQZFAtvlTNQCRWE2tykF/WG6K/McJthDw=="
     },
     "@serialport/parser-spacepacket": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-      "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-11.0.1.tgz",
+      "integrity": "sha512-Lq7fXoOsLOMo4XEt9HB31zV5LhrteXlsOy2o6r39TfRwU6x8Nou9jQMA9vW0a6yPra5zwsHIaNrA6tDOGj2Ozg=="
     },
     "@serialport/stream": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
-      "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-11.0.1.tgz",
+      "integrity": "sha512-6pjyKRg8MQuvhGfg36+PF7K5eGNQcEswCSiAg1UPilqqFS8X1QnaiSCn5UFp/hCN+pAtlFjkOi0ztvtmSI7n4g==",
       "requires": {
         "@serialport/bindings-interface": "1.2.2",
-        "debug": "^4.3.2"
+        "debug": "4.3.4"
       }
     },
     "@sinonjs/commons": {
@@ -11013,6 +11230,108 @@
       "requires": {
         "debug": "^4.1.1",
         "serialport": "^10.4.0"
+      },
+      "dependencies": {
+        "@serialport/bindings-cpp": {
+          "version": "10.8.0",
+          "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
+          "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
+          "requires": {
+            "@serialport/bindings-interface": "1.2.2",
+            "@serialport/parser-readline": "^10.2.1",
+            "debug": "^4.3.2",
+            "node-addon-api": "^5.0.0",
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "@serialport/parser-byte-length": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
+          "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
+        },
+        "@serialport/parser-cctalk": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
+          "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
+        },
+        "@serialport/parser-delimiter": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
+          "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
+        },
+        "@serialport/parser-inter-byte-timeout": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
+          "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
+        },
+        "@serialport/parser-packet-length": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
+          "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
+        },
+        "@serialport/parser-readline": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
+          "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+          "requires": {
+            "@serialport/parser-delimiter": "10.5.0"
+          }
+        },
+        "@serialport/parser-ready": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
+          "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
+        },
+        "@serialport/parser-regex": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
+          "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
+        },
+        "@serialport/parser-slip-encoder": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
+          "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
+        },
+        "@serialport/parser-spacepacket": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
+          "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
+        },
+        "@serialport/stream": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
+          "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
+          "requires": {
+            "@serialport/bindings-interface": "1.2.2",
+            "debug": "^4.3.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+          "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+        },
+        "serialport": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
+          "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
+          "requires": {
+            "@serialport/binding-mock": "10.2.2",
+            "@serialport/bindings-cpp": "10.8.0",
+            "@serialport/parser-byte-length": "10.5.0",
+            "@serialport/parser-cctalk": "10.5.0",
+            "@serialport/parser-delimiter": "10.5.0",
+            "@serialport/parser-inter-byte-timeout": "10.5.0",
+            "@serialport/parser-packet-length": "10.5.0",
+            "@serialport/parser-readline": "10.5.0",
+            "@serialport/parser-ready": "10.5.0",
+            "@serialport/parser-regex": "10.5.0",
+            "@serialport/parser-slip-encoder": "10.5.0",
+            "@serialport/parser-spacepacket": "10.5.0",
+            "@serialport/stream": "10.5.0",
+            "debug": "^4.3.3"
+          }
+        }
       }
     },
     "mqtt": {
@@ -11066,9 +11385,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node-gyp-build": {
       "version": "4.6.0",
@@ -11632,24 +11951,24 @@
       }
     },
     "serialport": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
-      "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-11.0.1.tgz",
+      "integrity": "sha512-j/ntDuewAkqL6g5wKjwV2RTyLBL9cpob8aRd3yLAViYApTsJoYqRleyuzst0OboNTBjBsoxQ4YKYhuYHi1XViQ==",
       "requires": {
         "@serialport/binding-mock": "10.2.2",
-        "@serialport/bindings-cpp": "10.8.0",
-        "@serialport/parser-byte-length": "10.5.0",
-        "@serialport/parser-cctalk": "10.5.0",
-        "@serialport/parser-delimiter": "10.5.0",
-        "@serialport/parser-inter-byte-timeout": "10.5.0",
-        "@serialport/parser-packet-length": "10.5.0",
-        "@serialport/parser-readline": "10.5.0",
-        "@serialport/parser-ready": "10.5.0",
-        "@serialport/parser-regex": "10.5.0",
-        "@serialport/parser-slip-encoder": "10.5.0",
-        "@serialport/parser-spacepacket": "10.5.0",
-        "@serialport/stream": "10.5.0",
-        "debug": "^4.3.3"
+        "@serialport/bindings-cpp": "11.0.3",
+        "@serialport/parser-byte-length": "11.0.1",
+        "@serialport/parser-cctalk": "11.0.1",
+        "@serialport/parser-delimiter": "11.0.1",
+        "@serialport/parser-inter-byte-timeout": "11.0.1",
+        "@serialport/parser-packet-length": "11.0.1",
+        "@serialport/parser-readline": "11.0.1",
+        "@serialport/parser-ready": "11.0.1",
+        "@serialport/parser-regex": "11.0.1",
+        "@serialport/parser-slip-encoder": "11.0.1",
+        "@serialport/parser-spacepacket": "11.0.1",
+        "@serialport/stream": "11.0.1",
+        "debug": "4.3.4"
       }
     },
     "serve-static": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "eslint-plugin-promise": "^6.1.1",
         "jest": "^27.4.7",
         "prettier": "^2.5.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/Jalle19/eda-modbus-bridge/issues"
   },
   "homepage": "https://github.com/Jalle19/eda-modbus-bridge#readme",
+  "engines": {
+    "node": ">= 14"
+  },
   "dependencies": {
     "async-mqtt": "^2.6.1",
     "async-mutex": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.18.2",
     "express-winston": "^4.2.0",
     "modbus-serial": "^8.0.11",
+    "serialport": "^11.0.1",
     "winston": "^3.10.0",
     "yargs": "^16.2.0"
   },


### PR DESCRIPTION
https://github.com/serialport/node-serialport/issues/2438 we want this

https://github.com/Jalle19/home-assistant-addon-repository/issues/30 to fix this

https://github.com/yaacov/node-modbus-serial/pull/501 latest master is broken for other reasons, so we can't simply update this one and get the new `serialport` transiently.

Additionally, `serialport` has dropped support for Node.js 12.x, so we have to drop it as well. It literally doesn't run anymore on 12.x.