### PR TITLE
Read unit type from the correct register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## future release
+
+* Fix reading from unit type from wrong register (https://github.com/Jalle19/eda-modbus-bridge/issues/100)
+
 ## 2.7.0
 
 * Change Home Assistant auto-discovery log level to `debug` (https://github.com/Jalle19/eda-modbus-bridge/issues/93)

--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -261,7 +261,7 @@ export const getDeviceInformation = async (modbusClient) => {
         'fanType': result.data[0] ? 'EC' : 'AC',
     }
 
-    result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 72, 1))
+    result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 51, 1))
     const unitType = getUnitTypeName(result.data[0])
     deviceInformation = {
         ...deviceInformation,


### PR DESCRIPTION
Should hopefully fix https://github.com/Jalle19/eda-modbus-bridge/issues/100