### PR TITLE
Implement support for acknowledging alarms

### DIFF
--- a/app/enervent.mjs
+++ b/app/enervent.mjs
@@ -38,8 +38,6 @@ export const AVAILABLE_SETTINGS = {
     'defrostingAllowed': 55,
 }
 
-export const ALARM_REGISTERS_START = 385
-export const ALARM_REGISTERS_END = 518
 export const AVAILABLE_ALARMS = {
     // Alarm number
     // Name and descr based on Enervent EN EDA Modbus regirsters: 3x0385

--- a/app/homeassistant.mjs
+++ b/app/homeassistant.mjs
@@ -337,12 +337,22 @@ export const configureMqttDiscovery = async (modbusClient, mqttClient) => {
         'defrosting': createDeviceStateConfiguration(configurationBase, 'defrosting', 'Defrosting'),
     }
 
+    // Button for acknowledging alarms
+    const buttonConfigurationMap = {
+        'acknowledgeAlarm': createButtonConfiguration(
+            configurationBase,
+            'acknowledgeAlarm',
+            'Acknowledge newest alarm'
+        ),
+    }
+
     // Final map that describes everything we want to be auto-discovered
     const configurationMap = {
         'sensor': sensorConfigurationMap,
         'number': numberConfigurationMap,
         'switch': switchConfigurationMap,
         'binary_sensor': binarySensorConfigurationMap,
+        'button': buttonConfigurationMap,
     }
 
     // Publish configurations
@@ -474,5 +484,15 @@ const createDeviceStateConfiguration = (configurationBase, stateName, entityName
         'object_id': `eda_state_${stateName}`,
         'state_topic': `${TOPIC_PREFIX_DEVICE_STATE}/${stateName}`,
         'entity_category': 'diagnostic',
+    }
+}
+
+const createButtonConfiguration = (configurationBase, buttonName, entityName) => {
+    return {
+        ...configurationBase,
+        'unique_id': `eda-button-${buttonName}`,
+        'name': entityName,
+        'object_id': `eda_button_${buttonName}`,
+        'command_topic': `${TOPIC_PREFIX_ALARM}/acknowledge`,
     }
 }

--- a/app/http.mjs
+++ b/app/http.mjs
@@ -6,8 +6,9 @@ import {
     getSettings,
     setMode as modbusSetMode,
     setSetting as modbusSetSetting,
-    getAlarmHistory,
     getDeviceState,
+    getNewestAlarm,
+    getAlarmSummary,
 } from './modbus.mjs'
 import { createLogger } from './logger.mjs'
 
@@ -20,6 +21,8 @@ const root = async (req, res) => {
 const summary = async (modbusClient, req, res) => {
     try {
         let modeSummary = await getModeSummary(modbusClient)
+        const newestAlarm = await getNewestAlarm(modbusClient)
+
         const summary = {
             // TODO: Remove in next major version
             'flags': modeSummary,
@@ -27,8 +30,9 @@ const summary = async (modbusClient, req, res) => {
             'readings': await getReadings(modbusClient),
             'settings': await getSettings(modbusClient),
             'deviceInformation': await getDeviceInformation(modbusClient),
-            'alarmHistory': await getAlarmHistory(modbusClient),
             'deviceState': await getDeviceState(modbusClient),
+            'alarmSummary': await getAlarmSummary(modbusClient),
+            'activeAlarm': newestAlarm?.state === 2 ? newestAlarm : null,
         }
 
         res.json(summary)

--- a/app/http.mjs
+++ b/app/http.mjs
@@ -6,6 +6,7 @@ import {
     getSettings,
     setMode as modbusSetMode,
     setSetting as modbusSetSetting,
+    acknowledgeAlarm as modbusAcknowledgeAlarm,
     getDeviceState,
     getNewestAlarm,
     getAlarmSummary,
@@ -92,6 +93,16 @@ const setSetting = async (modbusClient, req, res) => {
     }
 }
 
+const acknowledgeAlarm = async (modbusClient, req, res) => {
+    try {
+        logger.info('Acknowledging currently active alarm (if any)')
+
+        await modbusAcknowledgeAlarm(modbusClient)
+    } catch (e) {
+        handleError(e, res)
+    }
+}
+
 export const configureRoutes = (httpServer, modbusClient) => {
     httpServer.get('/', root)
     httpServer.get('/summary', (req, res) => {
@@ -105,6 +116,9 @@ export const configureRoutes = (httpServer, modbusClient) => {
     })
     httpServer.post('/setting/:setting/:value', (req, res) => {
         return setSetting(modbusClient, req, res)
+    })
+    httpServer.post('/alarm/acknowledge', (req, res) => {
+        return acknowledgeAlarm(modbusClient, req, res)
     })
 }
 

--- a/app/modbus.mjs
+++ b/app/modbus.mjs
@@ -374,6 +374,10 @@ export const getNewestAlarm = async (modbusClient) => {
     }
 }
 
+export const acknowledgeAlarm = async (modbusClient) => {
+    await tryWriteHoldingRegister(modbusClient, 386, 1)
+}
+
 export const getDeviceState = async (modbusClient) => {
     const result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 44, 1))
 

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -5,7 +5,7 @@ import {
     setSetting,
     getModeSummary,
     setMode,
-    getAlarmStatuses,
+    getAlarmSummary,
     getDeviceState,
 } from './modbus.mjs'
 import { createLogger } from './logger.mjs'
@@ -41,9 +41,10 @@ export const publishValues = async (modbusClient, mqttClient) => {
     // Publish each setting
     await publishSettings(modbusClient, mqttClient)
 
-    const alarmStatuses = await getAlarmStatuses(modbusClient)
+    // Publish alarm summary
+    const alarmSummary = await getAlarmSummary(modbusClient)
 
-    for (const [, alarm] of Object.entries(alarmStatuses)) {
+    for (const [, alarm] of Object.entries(alarmSummary)) {
         const topicName = `${TOPIC_PREFIX_ALARM}/${alarm.name}`
 
         topicMap[topicName] = createBinaryValue(alarm.state === 2)

--- a/app/mqtt.mjs
+++ b/app/mqtt.mjs
@@ -7,6 +7,7 @@ import {
     setMode,
     getAlarmSummary,
     getDeviceState,
+    acknowledgeAlarm,
 } from './modbus.mjs'
 import { createLogger } from './logger.mjs'
 
@@ -121,8 +122,12 @@ const publishTopics = async (mqttClient, topicMap, publishOptions = {}) => {
 }
 
 export const subscribeToChanges = async (modbusClient, mqttClient) => {
-    // Subscribe to settings and mode changes
-    const topicNames = [`${TOPIC_PREFIX_MODE}/+/set`, `${TOPIC_PREFIX_SETTINGS}/+/set`]
+    // Subscribe to writable topics
+    const topicNames = [
+        `${TOPIC_PREFIX_MODE}/+/set`,
+        `${TOPIC_PREFIX_SETTINGS}/+/set`,
+        `${TOPIC_PREFIX_ALARM}/acknowledge`,
+    ]
 
     for (const topicName of topicNames) {
         logger.info(`Subscribing to topic(s) ${topicName}`)
@@ -136,8 +141,8 @@ export const handleMessage = async (modbusClient, mqttClient, topicName, rawPayl
 
     const payload = parsePayload(rawPayload)
 
-    // Handle settings updates
     if (topicName.startsWith(TOPIC_PREFIX_SETTINGS) && topicName.endsWith('/set')) {
+        // Handle settings updates
         const settingName = topicName.substring(TOPIC_PREFIX_SETTINGS.length + 1, topicName.lastIndexOf('/'))
 
         logger.info(`Updating setting ${settingName} to ${payload}`)
@@ -145,12 +150,18 @@ export const handleMessage = async (modbusClient, mqttClient, topicName, rawPayl
         await setSetting(modbusClient, settingName, payload)
         await publishSettings(modbusClient, mqttClient)
     } else if (topicName.startsWith(TOPIC_PREFIX_MODE) && topicName.endsWith('/set')) {
+        // Handle mode changes
         const mode = topicName.substring(TOPIC_PREFIX_MODE.length + 1, topicName.lastIndexOf('/'))
 
         logger.info(`Updating mode ${mode} to ${payload}`)
 
         await setMode(modbusClient, mode, payload)
         await publishModeSummary(modbusClient, mqttClient)
+    } else if (topicName.startsWith(TOPIC_PREFIX_ALARM) && topicName.endsWith('/acknowledge')) {
+        // Acknowledge alarm
+        logger.info('Acknowledging currently active alarm (if any)')
+
+        await acknowledgeAlarm(modbusClient)
     }
 }
 


### PR DESCRIPTION
Only the newest alarm can be acknowledged, should be enough for most circumstances. If there are multiple alarms you probably want to investigate before blindly acknowledging it anyway.