### PR TITLE
Make supply/exhaust fan speed during overpressure configurable

### DIFF
--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -39,6 +39,8 @@ export const AVAILABLE_SETTINGS: Record<string, number> = {
     'longAwayCoolingAllowed': 21,
     'longAwayHeatingAllowed': 20,
     'defrostingAllowed': 55,
+    'supplyFanOverPressure': 54,
+    'exhaustFanOverPressure': 55,
 }
 
 export type AlarmDescription = {
@@ -134,6 +136,8 @@ export type Settings = {
     longAwayCoolingAllowed?: boolean
     longAwayHeatingAllowed?: boolean
     defrostingAllowed: boolean
+    supplyFanOverPressure: number
+    exhaustFanOverPressure: number
 }
 
 export type DeviceInformation = {

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -251,6 +251,26 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
             'max': 30,
             'unit_of_measurement': '°C',
         }),
+        'supplyFanOverPressure': createNumberConfiguration(
+            configurationBase,
+            'supplyFanOverPressure',
+            'Supply fan speed (during overpressure)',
+            {
+                min: 20,
+                max: 100,
+                'unit_of_measurement': '%',
+            }
+        ),
+        'exhaustFanOverPressure': createNumberConfiguration(
+            configurationBase,
+            'exhaustFanOverPressure',
+            'Exhaust fan speed (during overpressure)',
+            {
+                min: 20,
+                max: 100,
+                'unit_of_measurement': '%',
+            }
+        ),
     }
 
     // Configurable switches


### PR DESCRIPTION
The idea is to be able to dynamically adjust these to simulate the different levels used when optional sensors are added for liesituuletin, keskuspölynimuri etc.