### PR TITLE
Add decimal support for temperature settings and refactor AVAILABLE_SETTINGS

### DIFF
--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -24,23 +24,26 @@ export const MUTUALLY_EXCLUSIVE_MODES: Record<string, number> = {
     'eco': 40,
 }
 
-export const AVAILABLE_SETTINGS: Record<string, number> = {
-    'overPressureDelay': 57,
-    'awayVentilationLevel': 100,
-    'awayTemperatureReduction': 101,
-    'longAwayVentilationLevel': 102,
-    'longAwayTemperatureReduction': 103,
-    'temperatureControlMode': 136,
-    'temperatureTarget': 135,
-    'coolingAllowed': 52,
-    'heatingAllowed': 54,
-    'awayCoolingAllowed': 19,
-    'awayHeatingAllowed': 18,
-    'longAwayCoolingAllowed': 21,
-    'longAwayHeatingAllowed': 20,
-    'defrostingAllowed': 55,
-    'supplyFanOverPressure': 54,
-    'exhaustFanOverPressure': 55,
+export const AVAILABLE_SETTINGS: Record<
+    string,
+    { dataAddress: number; decimalPrecision: number; registerType: 'coil' | 'holding' }
+> = {
+    'overPressureDelay': { dataAddress: 57, decimalPrecision: 0, registerType: 'holding' },
+    'awayVentilationLevel': { dataAddress: 100, decimalPrecision: 0, registerType: 'holding' },
+    'awayTemperatureReduction': { dataAddress: 101, decimalPrecision: 0, registerType: 'holding' },
+    'longAwayVentilationLevel': { dataAddress: 102, decimalPrecision: 0, registerType: 'holding' },
+    'longAwayTemperatureReduction': { dataAddress: 103, decimalPrecision: 0, registerType: 'holding' },
+    'temperatureControlMode': { dataAddress: 136, decimalPrecision: 0, registerType: 'holding' },
+    'temperatureTarget': { dataAddress: 135, decimalPrecision: 1, registerType: 'holding' },
+    'coolingAllowed': { dataAddress: 52, decimalPrecision: 0, registerType: 'coil' },
+    'heatingAllowed': { dataAddress: 54, decimalPrecision: 0, registerType: 'coil' },
+    'awayCoolingAllowed': { dataAddress: 19, decimalPrecision: 0, registerType: 'coil' },
+    'awayHeatingAllowed': { dataAddress: 18, decimalPrecision: 0, registerType: 'coil' },
+    'longAwayCoolingAllowed': { dataAddress: 21, decimalPrecision: 0, registerType: 'coil' },
+    'longAwayHeatingAllowed': { dataAddress: 20, decimalPrecision: 0, registerType: 'coil' },
+    'defrostingAllowed': { dataAddress: 55, decimalPrecision: 0, registerType: 'coil' },
+    'supplyFanOverPressure': { dataAddress: 54, decimalPrecision: 0, registerType: 'holding' },
+    'exhaustFanOverPressure': { dataAddress: 55, decimalPrecision: 0, registerType: 'holding' },
 }
 
 export enum TemperatureControlState {

--- a/tests/modbus.test.ts
+++ b/tests/modbus.test.ts
@@ -1,4 +1,4 @@
-import { validateDevice, parseDevice, ModbusDeviceType } from '../app/modbus'
+import { validateDevice, parseDevice, ModbusDeviceType, parseSettingValue } from '../app/modbus'
 
 test('validateDevice', () => {
     expect(validateDevice('/dev/ttyUSB0')).toEqual(true)
@@ -22,4 +22,18 @@ test('parseDevice', () => {
         hostname: '127.0.0.1',
         port: 502,
     })
+})
+
+test('parseSettingValue', () => {
+    // Settings with decimals should parse floats
+    expect(parseSettingValue('temperatureTarget', '22.0')).toEqual(22)
+    expect(parseSettingValue('temperatureTarget', '22')).toEqual(22)
+    expect(parseSettingValue('temperatureTarget', '22.5')).toEqual(22.5)
+    expect(parseSettingValue('temperatureTarget', '18.75')).toEqual(18.8)
+    expect(parseSettingValue('temperatureTarget', '18.74')).toEqual(18.7)
+
+    // Settings without decimals should parse integers (truncates decimals)
+    expect(parseSettingValue('awayVentilationLevel', '50.5')).toEqual(50)
+    expect(parseSettingValue('awayVentilationLevel', '50')).toEqual(50)
+    expect(parseSettingValue('overPressureDelay', '30')).toEqual(30)
 })


### PR DESCRIPTION
Added decimal support for `temperatureTarget` setting and refactored the settings configuration.

Note:
My device (Enervent Pingvin Kotilampo W) accepts decimal values for temperature setpoint via Modbus, even though the control panel only displays integers. This is useful for automation/fine-tuning. Not sure if all models support this, so feel free to reject if you think this adds unnecessary complexity.


**Changes:**
  - Refactored `AVAILABLE_SETTINGS` to use structured objects instead of just addresses (addresses appeared to be duplicate, but this was due to coil/holding register distinction, so made it more clear)
  - Added `decimalPrecision` field to support decimal values
  - Added `registerType: 'coil' | 'holding'` to clarify Modbus register types
  - Extracted `parseSettingValue()` for testable decimal parsing logic
  - Added tests for decimal precision handling