### PR TITLE
Treat "eco" as a setting instead of a mode

### DIFF
--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -7,7 +7,6 @@ export const AVAILABLE_MODES: Record<string, number> = {
     'maxHeating': 6,
     'maxCooling': 7,
     'manualBoost': 10,
-    'eco': 40,
 }
 
 interface BaseSettingConfiguration {
@@ -54,6 +53,7 @@ export const AVAILABLE_SETTINGS: Record<string, SettingConfiguration> = {
     'summerNightCoolingAllowed': { dataAddress: 12, registerType: 'coil' },
     'supplyFanOverPressure': { dataAddress: 54, decimals: 0, registerType: 'holding', min: 20, max: 100 },
     'exhaustFanOverPressure': { dataAddress: 55, decimals: 0, registerType: 'holding', min: 20, max: 100 },
+    'eco': { dataAddress: 40, registerType: 'coil' },
 }
 
 export enum TemperatureControlState {
@@ -163,6 +163,7 @@ export type Settings = {
     summerNightCoolingAllowed: boolean
     supplyFanOverPressure: number
     exhaustFanOverPressure: number
+    eco: boolean
 }
 
 export type DeviceInformation = {

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -291,14 +291,14 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
         'maxHeating': createModeSwitchConfiguration(configurationBase, 'maxHeating', 'Max heating'),
         'maxCooling': createModeSwitchConfiguration(configurationBase, 'maxCooling', 'Max cooling'),
         'manualBoost': createModeSwitchConfiguration(configurationBase, 'manualBoost', 'Manual boost'),
-        'eco': createModeSwitchConfiguration(
+        // Settings switches
+        'eco': createSettingSwitchConfiguration(
             configurationBase,
             'eco',
             'Eco',
             // Not supported by some units
             { 'enabled_by_default': automationType === AutomationType.MD }
         ),
-        // Settings switches
         'coolingAllowed': createSettingSwitchConfiguration(
             configurationBase,
             'coolingAllowed',

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -276,6 +276,15 @@ export const getSettings = async (modbusClient: ModbusRTU): Promise<Settings> =>
         'exhaustFanOverPressure': result.data[1],
     }
 
+    // Eco mode (not available on all units)
+    if (deviceInformation.automationType === AutomationType.MD) {
+        result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 40, 1))
+        settings = {
+            ...settings,
+            'eco': result.data[0],
+        }
+    }
+
     return settings as Settings
 }
 


### PR DESCRIPTION
It seems like it's not actually a real mode, more like an extra option that controls how the unit behaves in general. Makes it easier to refactor how we handle modes, since now all units have all modes available.