### PR TITLE
feat: add cooker hood, central vacuum and writable fan levels

### DIFF
--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -54,6 +54,14 @@ export const AVAILABLE_SETTINGS: Record<string, SettingConfiguration> = {
     'supplyFanOverPressure': { dataAddress: 54, decimals: 0, registerType: 'holding', min: 20, max: 100 },
     'exhaustFanOverPressure': { dataAddress: 55, decimals: 0, registerType: 'holding', min: 20, max: 100 },
     'eco': { dataAddress: 40, registerType: 'coil' },
+    // Auxiliary function coils (on/off, independent of the operating modes)
+    'cookerHood': { dataAddress: 4, registerType: 'coil' },
+    'centralVacuumCleaner': { dataAddress: 5, registerType: 'coil' },
+    // Writable fan levels (percent). "ventilationLevel" is the target level normally
+    // set from the control panel; the base speeds are the per-fan setpoints.
+    'ventilationLevel': { dataAddress: 53, decimals: 0, registerType: 'holding', min: 20, max: 100 },
+    'supplyFanBaseSpeed': { dataAddress: 51, decimals: 0, registerType: 'holding', min: 20, max: 100 },
+    'exhaustFanBaseSpeed': { dataAddress: 52, decimals: 0, registerType: 'holding', min: 20, max: 100 },
 }
 
 export enum TemperatureControlState {
@@ -164,6 +172,11 @@ export type Settings = {
     supplyFanOverPressure: number
     exhaustFanOverPressure: number
     eco: boolean
+    cookerHood: boolean
+    centralVacuumCleaner: boolean
+    ventilationLevel: number
+    supplyFanBaseSpeed: number
+    exhaustFanBaseSpeed: number
 }
 
 export type DeviceInformation = {

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -280,6 +280,31 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
                 'unit_of_measurement': '%',
             }
         ),
+        'ventilationLevel': createNumberConfiguration(configurationBase, 'ventilationLevel', 'Ventilation level', {
+            min: 20,
+            max: 100,
+            'unit_of_measurement': '%',
+        }),
+        'supplyFanBaseSpeed': createNumberConfiguration(
+            configurationBase,
+            'supplyFanBaseSpeed',
+            'Supply fan base speed',
+            {
+                min: 20,
+                max: 100,
+                'unit_of_measurement': '%',
+            }
+        ),
+        'exhaustFanBaseSpeed': createNumberConfiguration(
+            configurationBase,
+            'exhaustFanBaseSpeed',
+            'Exhaust fan base speed',
+            {
+                min: 20,
+                max: 100,
+                'unit_of_measurement': '%',
+            }
+        ),
     }
 
     // Configurable switches
@@ -350,6 +375,13 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
             configurationBase,
             'summerNightCoolingAllowed',
             'Summer night cooling allowed'
+        ),
+        // Auxiliary functions (on/off), independent of the operating modes
+        'cookerHood': createSettingSwitchConfiguration(configurationBase, 'cookerHood', 'Cooker hood'),
+        'centralVacuumCleaner': createSettingSwitchConfiguration(
+            configurationBase,
+            'centralVacuumCleaner',
+            'Central vacuum cleaner'
         ),
     }
 

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -268,6 +268,23 @@ export const getSettings = async (modbusClient: ModbusRTU): Promise<Settings> =>
         'summerNightCoolingAllowed': result.data[0],
     }
 
+    // Auxiliary function coils (cooker hood = 4, central vacuum cleaner = 5)
+    result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 4, 2))
+    settings = {
+        ...settings,
+        'cookerHood': result.data[0],
+        'centralVacuumCleaner': result.data[1],
+    }
+
+    // Writable fan levels (supply base = 51, exhaust base = 52, ventilation level = 53)
+    result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 51, 3))
+    settings = {
+        ...settings,
+        'supplyFanBaseSpeed': result.data[0],
+        'exhaustFanBaseSpeed': result.data[1],
+        'ventilationLevel': result.data[2],
+    }
+
     // Fan speeds during over-pressurization
     result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 54, 2))
     settings = {

--- a/tests/modbus.test.ts
+++ b/tests/modbus.test.ts
@@ -103,6 +103,24 @@ describe('setSetting', () => {
             await setSetting(mockClient, 'temperatureControlMode', '2')
             expect(mockClient.writeRegister).toHaveBeenCalledWith(136, 2) // no validation, no scaling
         })
+
+        test('should write fan level settings', async () => {
+            await setSetting(mockClient, 'ventilationLevel', '60')
+            expect(mockClient.writeRegister).toHaveBeenCalledWith(53, 60)
+
+            await setSetting(mockClient, 'supplyFanBaseSpeed', '34')
+            expect(mockClient.writeRegister).toHaveBeenCalledWith(51, 34)
+
+            await setSetting(mockClient, 'exhaustFanBaseSpeed', '35')
+            expect(mockClient.writeRegister).toHaveBeenCalledWith(52, 35)
+        })
+
+        test('should enforce the fan level minimum of 20', async () => {
+            await expect(setSetting(mockClient, 'ventilationLevel', '10')).rejects.toThrow('value 10 below minimum 20')
+
+            await setSetting(mockClient, 'ventilationLevel', '20')
+            expect(mockClient.writeRegister).toHaveBeenCalledWith(53, 20)
+        })
     })
 
     describe('coil settings (boolean)', () => {
@@ -112,6 +130,14 @@ describe('setSetting', () => {
 
             await setSetting(mockClient, 'heatingAllowed', false)
             expect(mockClient.writeCoil).toHaveBeenCalledWith(54, false)
+        })
+
+        test('should write auxiliary function coils', async () => {
+            await setSetting(mockClient, 'cookerHood', true)
+            expect(mockClient.writeCoil).toHaveBeenCalledWith(4, true)
+
+            await setSetting(mockClient, 'centralVacuumCleaner', true)
+            expect(mockClient.writeCoil).toHaveBeenCalledWith(5, true)
         })
 
         test('should reject string values for coil settings', async () => {


### PR DESCRIPTION
Expose two new auxiliary-function coil switches and three writable ventilation number entities through the existing AVAILABLE_SETTINGS mechanism, so they are published over MQTT and available via Home Assistant discovery and the /setting HTTP endpoint like any other setting:

- switch: cookerHood (coil 4), centralVacuumCleaner (coil 5)
- number: ventilationLevel (reg 53), supplyFanBaseSpeed (reg 51), exhaustFanBaseSpeed (reg 52)

Note: as documented under "known issues", some firmwares do not accept ventilation level changes while the unit is in normal mode.