### PR TITLE
writeCoils(), writeRegisters(), added Fan Speed Control

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -30,6 +30,7 @@ export type SettingConfiguration = CoilSettingConfiguration | HoldingRegisterSet
 
 export const AVAILABLE_SETTINGS: Record<string, SettingConfiguration> = {
     'overPressureDelay': { dataAddress: 57, decimals: 0, registerType: 'holding', min: 0, max: 60 },
+    'ventilationLevel': { dataAddress: 53, decimals: 0, registerType: 'holding', min: 20, max: 100 },
     'awayVentilationLevel': { dataAddress: 100, decimals: 0, registerType: 'holding', min: 20, max: 100 },
     'awayTemperatureReduction': { dataAddress: 101, decimals: 0, registerType: 'holding', registerScale: 10 },
     'longAwayVentilationLevel': { dataAddress: 102, decimals: 0, registerType: 'holding', min: 20, max: 100 },
@@ -147,6 +148,7 @@ export type Readings = {
 
 export type Settings = {
     overPressureDelay: number
+    ventilationLevel: number
     awayVentilationLevel: number
     awayTemperatureReduction: number
     longAwayVentilationLevel: number

--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -45,6 +45,8 @@ export const AVAILABLE_SETTINGS: Record<string, SettingConfiguration> = {
         max: 30,
     },
     'coolingAllowed': { dataAddress: 52, registerType: 'coil' },
+    // COIL_LTO_EN. Only implemented on EDA automation, reads as "not used" on MD.
+    'heatRecoveryAllowed': { dataAddress: 53, registerType: 'coil' },
     'heatingAllowed': { dataAddress: 54, registerType: 'coil' },
     'awayCoolingAllowed': { dataAddress: 19, registerType: 'coil' },
     'awayHeatingAllowed': { dataAddress: 18, registerType: 'coil' },
@@ -156,6 +158,7 @@ export type Settings = {
     temperatureTarget: number
     temperatureControlMode: number
     coolingAllowed?: boolean
+    heatRecoveryAllowed?: boolean
     heatingAllowed?: boolean
     awayCoolingAllowed?: boolean
     awayHeatingAllowed?: boolean

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -215,6 +215,16 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
             'max': 60,
             'unit_of_measurement': 'minutes',
         }),
+        'ventilationLevel': createNumberConfiguration(
+            configurationBase,
+            'ventilationLevel',
+            'Ventilation level',
+            {
+                'min': 20,
+                'max': 100,
+                'unit_of_measurement': '%',
+            }
+        ),
         'awayVentilationLevel': createNumberConfiguration(
             configurationBase,
             'awayVentilationLevel',

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -316,6 +316,13 @@ export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient
             // Not supported by some units
             { 'enabled_by_default': automationType !== AutomationType.LEGACY_EDA }
         ),
+        'heatRecoveryAllowed': createSettingSwitchConfiguration(
+            configurationBase,
+            'heatRecoveryAllowed',
+            'Heat recovery allowed',
+            // Only implemented on EDA automation
+            { 'enabled_by_default': automationType === AutomationType.EDA }
+        ),
         'heatingAllowed': createSettingSwitchConfiguration(
             configurationBase,
             'heatingAllowed',

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -486,7 +486,7 @@ const tryReadCoils = async (modbusClient: ModbusRTU, dataAddress: number, length
 const tryWriteCoil = async (modbusClient: ModbusRTU, dataAddress: number, value: boolean) => {
     try {
         logger.debug(`Writing ${value} to coil address ${dataAddress}`)
-        return await modbusClient.writeCoil(dataAddress, value)
+        return await modbusClient.writeCoils(dataAddress, value)
     } catch (e) {
         logger.error(`Failed to write coil address ${dataAddress}, value ${value}`)
         throw e

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -217,6 +217,14 @@ export const getSettings = async (modbusClient: ModbusRTU): Promise<Settings> =>
         'overPressureDelay': result.data[0],
     }
 
+    // Home/normal ventilation level (register 53) — the everyday fan-speed setpoint.
+    // This is the writable counterpart of the read-only "ventilationLevelTarget" reading.
+    result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 53, 1))
+    settings = {
+        ...settings,
+        'ventilationLevel': result.data[0],
+    }
+
     result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 100, 4))
     settings = {
         ...settings,

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -486,7 +486,7 @@ const tryReadCoils = async (modbusClient: ModbusRTU, dataAddress: number, length
 const tryWriteCoil = async (modbusClient: ModbusRTU, dataAddress: number, value: boolean) => {
     try {
         logger.debug(`Writing ${value} to coil address ${dataAddress}`)
-        return await modbusClient.writeCoils(dataAddress, value)
+        return await modbusClient.writeCoils(dataAddress, [value])
     } catch (e) {
         logger.error(`Failed to write coil address ${dataAddress}, value ${value}`)
         throw e

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -252,6 +252,14 @@ export const getSettings = async (modbusClient: ModbusRTU): Promise<Settings> =>
             'heatingAllowed': result.data[2],
         }
 
+        // Coil 53 (COIL_LTO_EN) is only implemented on EDA automation, it reads as "not used" on MD
+        if (deviceInformation.automationType === AutomationType.EDA) {
+            settings = {
+                ...settings,
+                'heatRecoveryAllowed': result.data[1],
+            }
+        }
+
         result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 18, 4))
         settings = {
             ...settings,

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -506,7 +506,7 @@ const tryReadHoldingRegisters = async (modbusClient: ModbusRTU, dataAddress: num
 const tryWriteHoldingRegister = async (modbusClient: ModbusRTU, dataAddress: number, value: number) => {
     try {
         logger.debug(`Writing ${value} to holding register address ${dataAddress}`)
-        return await modbusClient.writeRegister(dataAddress, value)
+        return await modbusClient.writeRegisters(dataAddress, [value])
     } catch (e) {
         logger.error(`Failed to write holding register address ${dataAddress}, value ${value}`)
         throw e

--- a/docs/HTTP.md
+++ b/docs/HTTP.md
@@ -56,6 +56,7 @@ Returns a JSON object like this:
     "longAwayTemperatureReduction": 0,
     "temperatureTarget": 17,
     "coolingAllowed": true,
+    "heatRecoveryAllowed": true,
     "heatingAllowed": true,
     "awayCoolingAllowed": true,
     "awayHeatingAllowed": false,

--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -73,6 +73,7 @@ eda/readings/exhaustFanSpeed
 eda/readings/returnWaterTemperature
 eda/readings/exhaustAirTemperatureBeforeHeatRecovery
 eda/settings/coolingAllowed
+eda/settings/heatRecoveryAllowed
 eda/settings/heatingAllowed
 eda/settings/awayCoolingAllowed
 eda/settings/awayHeatingAllowed

--- a/tests/modbus.test.ts
+++ b/tests/modbus.test.ts
@@ -113,6 +113,9 @@ describe('setSetting', () => {
             await setSetting(mockClient, 'coolingAllowed', true)
             expect(mockClient.writeCoils).toHaveBeenCalledWith(52, [true])
 
+            await setSetting(mockClient, 'heatRecoveryAllowed', true)
+            expect(mockClient.writeCoils).toHaveBeenCalledWith(53, [true])
+
             await setSetting(mockClient, 'heatingAllowed', false)
             expect(mockClient.writeCoils).toHaveBeenCalledWith(54, [false])
         })

--- a/tests/modbus.test.ts
+++ b/tests/modbus.test.ts
@@ -29,40 +29,43 @@ describe('setSetting', () => {
     let mockClient: ModbusRTU
 
     beforeEach(() => {
+        // We deliberately write via the multi-write function codes (FC15/FC16) rather than the
+        // single-write ones (FC05/FC06), since some Modbus TCP gateways silently drop the latter.
+        // The values are therefore always passed as single-element arrays.
         mockClient = {
-            writeRegister: jest.fn().mockResolvedValue(undefined),
-            writeCoil: jest.fn().mockResolvedValue(undefined),
+            writeRegisters: jest.fn().mockResolvedValue(undefined),
+            writeCoils: jest.fn().mockResolvedValue(undefined),
         } as any
     })
 
     describe('holding register settings (numeric)', () => {
         test('should accept string values for numeric settings', async () => {
             await setSetting(mockClient, 'temperatureTarget', '22.5')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 225) // 22.5 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [225]) // 22.5 * 10
         })
 
         test('should parse and round decimal values correctly', async () => {
             await setSetting(mockClient, 'temperatureTarget', '22.0')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 220)
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [220])
 
             await setSetting(mockClient, 'temperatureTarget', '18.75')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 188) // rounds to 18.8 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [188]) // rounds to 18.8 * 10
 
             await setSetting(mockClient, 'temperatureTarget', '18.74')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 187) // rounds to 18.7 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [187]) // rounds to 18.7 * 10
         })
 
         test('should parse integer strings for settings without decimals', async () => {
             await setSetting(mockClient, 'awayVentilationLevel', '50')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(100, 50)
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(100, [50])
 
             await setSetting(mockClient, 'overPressureDelay', '30')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(57, 30)
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(57, [30])
         })
 
         test('should truncate decimals for integer-only settings', async () => {
             await setSetting(mockClient, 'awayVentilationLevel', '50.5')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(100, 50) // truncates to 50
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(100, [50]) // truncates to 50
         })
 
         test('should reject boolean values for numeric settings', async () => {
@@ -73,12 +76,12 @@ describe('setSetting', () => {
 
         test('should apply registerScale when set', async () => {
             await setSetting(mockClient, 'awayTemperatureReduction', '5')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(101, 50) // 5 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(101, [50]) // 5 * 10
         })
 
         test('should not scale when registerScale is not set', async () => {
             await setSetting(mockClient, 'awayVentilationLevel', '75')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(100, 75) // no scaling
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(100, [75]) // no scaling
         })
 
         test('should enforce min/max validation', async () => {
@@ -88,30 +91,30 @@ describe('setSetting', () => {
 
         test('should allow values within min/max range', async () => {
             await setSetting(mockClient, 'temperatureTarget', '20')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 200) // 20 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [200]) // 20 * 10
         })
 
         test('should accept boundary values for min/max', async () => {
             await setSetting(mockClient, 'temperatureTarget', '10')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 100) // 10 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [100]) // 10 * 10
 
             await setSetting(mockClient, 'temperatureTarget', '30')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(135, 300) // 30 * 10
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(135, [300]) // 30 * 10
         })
 
         test('should handle settings without min/max', async () => {
             await setSetting(mockClient, 'temperatureControlMode', '2')
-            expect(mockClient.writeRegister).toHaveBeenCalledWith(136, 2) // no validation, no scaling
+            expect(mockClient.writeRegisters).toHaveBeenCalledWith(136, [2]) // no validation, no scaling
         })
     })
 
     describe('coil settings (boolean)', () => {
         test('should accept boolean values for coil settings', async () => {
             await setSetting(mockClient, 'coolingAllowed', true)
-            expect(mockClient.writeCoil).toHaveBeenCalledWith(52, true)
+            expect(mockClient.writeCoils).toHaveBeenCalledWith(52, [true])
 
             await setSetting(mockClient, 'heatingAllowed', false)
-            expect(mockClient.writeCoil).toHaveBeenCalledWith(54, false)
+            expect(mockClient.writeCoils).toHaveBeenCalledWith(54, [false])
         })
 
         test('should reject string values for coil settings', async () => {


### PR DESCRIPTION
Contains the fixes that allow saving coils (FC15 instead of FC05) and register (FC16 instead of FC06) values. 

Also added the Fan Speed Control to register 53.