### PR TITLE
Enervent cloud modbus client

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ settings), as well as an MQTT client which can publish readings/settings regular
 ventilation unit.
 
 Communication happens over RS-485 (Modbus RTU) by connecting a serial device to the "Freeway" port on the ventilation 
-unit's computer board, or alternatively using Modbus TCP for newer units that can be connected to the local network.
+unit's computer board, or alternatively using Modbus TCP for newer units that can be connected to the local network. 
+Units registered with Enervent's cloud service can also be reached through it, without any local connection to the unit.
 
 ## Table of contents
 
@@ -19,6 +20,7 @@ unit's computer board, or alternatively using Modbus TCP for newer units that ca
   * [Running as a systemd service](#running-as-a-systemd-service)
   * [Running as a Home Assistant OS addon](#running-as-a-home-assistant-os-addon)
 * [Usage](#usage)
+  * [Connecting over the cloud](#connecting-over-the-cloud)
 * [HTTP endpoints](#http-endpoints)
 * [MQTT support](#mqtt-support)
   * [Home Assistant MQTT discovery](#home-assistant-mqtt-discovery)
@@ -38,7 +40,7 @@ unit's computer board, or alternatively using Modbus TCP for newer units that ca
 * An Enervent ventilation unit with EDA or MD automation (Pingvin, Pandion, Pelican and LTR-3 confirmed working)
 * An RS-485 device (e.g. `/dev/ttyUSB0`) connected to the Enervent unit's Freeway port (see 
   [docs/CONNECTION.md](./docs/CONNECTION.md) for details on how to connect to the unit). Newer units that can be
-  connected directly to the local network don't need this.
+  connected directly to the local network don't need this, neither do units reached through Enervent's cloud service.
 
 ## Installation
 
@@ -86,27 +88,42 @@ node dist/eda-modbus-bridge.js [options]
 Options:
       --help                 Show help                                 [boolean]
       --version              Show version number                       [boolean]
-  -d, --device               The serial device to use, e.g. /dev/ttyUSB0
-                                                                      [required]
-  -s, --modbusSlave          The Modbus slave address               [default: 1]
+  -d, --device               The Modbus device to use, e.g. /dev/ttyUSB0 for
+                             Modbus RTU, tcp://192.168.1.40:502 for Modbus TCP
+                             or cloud://123456:1234 for the Enervent cloud
+                             service                         [string] [required]
+  -s, --modbusSlave          The Modbus slave address      [number] [default: 1]
+  -t, --modbusTimeout        The timeout for Modbus operations (in seconds)
+                                                           [number] [default: 5]
       --http                 Whether to enable the HTTP server or not
                                                        [boolean] [default: true]
-  -a, --httpListenAddress    The address to listen (HTTP)   [default: "0.0.0.0"]
-  -p, --httpPort             The port to listen on (HTTP)        [default: 8080]
-  -m, --mqttBrokerUrl        The URL to the MQTT broker, e.g. mqtt://localhost:18
-                             83. Omit to disable MQTT support.
-      --mqttUsername         The username to use when connecting to the MQTT bro
-                             ker. Omit to disable authentication.
-      --mqttPassword         The password to use when connecting to the MQTT bro
-                             ker. Required when mqttUsername is defined. Omit to
-                              disable authentication.
-  -i, --mqttPublishInterval  How often messages should be published over MQTT (i
-                             n seconds)                            [default: 10]
-      --mqttDiscovery        Whether to enable Home Assistant MQTT discovery sup
-                             port. Only effective when mqttBrokerUrl is defined.
-                                                       [boolean] [default: true]
+  -a, --httpListenAddress    The address to listen (HTTP)
+                                                   [string] [default: "0.0.0.0"]
+  -p, --httpPort             The port to listen on (HTTP)
+                                                        [number] [default: 8080]
+  -m, --mqttBrokerUrl        The URL to the MQTT broker, e.g.
+                             mqtt://localhost:1883. Omit to disable MQTT
+                             support.                                   [string]
+      --mqttUsername         The username to use when connecting to the MQTT
+                             broker. Omit to disable authentication.
+      --mqttPassword         The password to use when connecting to the MQTT
+                             broker. Required when mqttUsername is defined. Omit
+                             to disable authentication.
+  -i, --mqttPublishInterval  How often messages should be published over MQTT
+                             (in seconds)                          [default: 10]
+      --mqttDiscovery        Whether to enable Home Assistant MQTT discovery
+                             support. Only effective when mqttBrokerUrl is
+                             defined.                  [boolean] [default: true]
   -v, --debug                Enable debug logging     [boolean] [default: false]
 ```
+
+### Connecting over the cloud
+
+Units registered with Enervent's cloud service can be reached with `cloud://<serial number>:<PIN>`, using the same 
+serial number and PIN as https://my.enervent.com. No local network access to the ventilation unit is needed.
+
+Cloud support is experimental. The unit pushes register values to the cloud instead of being polled, so readings can be 
+slightly stale, and writes to registers the unit reports as read-only are refused rather than attempted.
 
 ## HTTP endpoints
 

--- a/app/client.ts
+++ b/app/client.ts
@@ -1,0 +1,15 @@
+export type CoilResult = {
+    data: boolean[]
+}
+
+export type RegisterResult = {
+    data: number[]
+}
+
+// Structurally satisfied by both ModbusRTU and EnerventCloudClient, neither of which declares it
+export interface ModbusClient {
+    readCoils(dataAddress: number, length: number): Promise<CoilResult>
+    writeCoil(dataAddress: number, state: boolean): Promise<unknown>
+    readHoldingRegisters(dataAddress: number, length: number): Promise<RegisterResult>
+    writeRegister(dataAddress: number, value: number): Promise<unknown>
+}

--- a/app/cloud.ts
+++ b/app/cloud.ts
@@ -1,0 +1,616 @@
+import { createLogger } from './logger'
+import type { CoilResult, ModbusClient, RegisterResult } from './client'
+import { io, Socket } from 'socket.io-client'
+import tls from 'tls'
+
+const logger = createLogger('cloud')
+
+const MY_ENERVENT_URL = 'https://my.enervent.com'
+
+// my.enervent.com serves only its leaf certificate, so the issuing intermediate has to be supplied
+// here for the chain to verify. Refresh from the leaf's AIA extension when the certificate is
+// reissued under a different CA:
+//   openssl s_client -connect my.enervent.com:443 -servername my.enervent.com </dev/null \
+//     | openssl x509 -noout -ext authorityInfoAccess
+// Current issuer: C=AT, O=ZeroSSL GmbH, CN=ZeroSSL RSA DV SSL CA 2 (expires 2035-09-23),
+// which chains to Sectigo Public Server Authentication Root R46 in Node's bundled root store.
+const ZEROSSL_INTERMEDIATE_CA = `-----BEGIN CERTIFICATE-----
+MIIGITCCBAmgAwIBAgIRANCpCCVfjlDl8zltERRwKjcwDQYJKoZIhvcNAQEMBQAw
+XzELMAkGA1UEBhMCR0IxGDAWBgNVBAoTD1NlY3RpZ28gTGltaXRlZDE2MDQGA1UE
+AxMtU2VjdGlnbyBQdWJsaWMgU2VydmVyIEF1dGhlbnRpY2F0aW9uIFJvb3QgUjQ2
+MB4XDTI1MDkyNDAwMDAwMFoXDTM1MDkyMzIzNTk1OVowRjELMAkGA1UEBhMCQVQx
+FTATBgNVBAoTDFplcm9TU0wgR21iSDEgMB4GA1UEAxMXWmVyb1NTTCBSU0EgRFYg
+U1NMIENBIDIwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCnXX3Qm/G+
+ujylvYIkhJ53ZZ7XM03vXY03sCnO9VWjwMsV0qCQMlvhuRiJwrm4M5jgGehxIiCR
+1qT0AyL2rHTWJR07vjJzuNmp7uoKu3HKwixBk9QuXD5aliO8/EDbzdZDcG/Hm5pC
+mOeusLtds/UE/Iq24nw5WpcgZE5Ly+F/yCYDuEa7hXLJAPM5SecJIblG1OQ3ukMl
+HHNBbDxBpGWTyDudd0DTed0NTgCPs1t8RZPhW9Gt/8nDwFX0pQ4eHfPEB8c6eNl2
+sRr2Afp1YErakR+53yEX2SXc2Kz0fbTlUc+To0ULGcJiWNyZwj//DTZ+M4xxsT2T
+qjQ4Xfvm2EUTymrXDrh1Pm/wkBouu860c6eeQfNlKlccUyHOSeKCtPIWreMvH3Be
+Ydeu3DwI8lefn/VUhSB2Bbz7hX3qz3oMmtSTmWhTnobyKlx1L2b/oloaqpy1cBc/
+QiLRSOptYGPjZtX0pRrTVKQXeP2rPUk0y5q/40WRpugSlHCX6aceWnsCAwEAAaOC
+AW8wggFrMB8GA1UdIwQYMBaAFFZzWGSV+ZIasBIqBGJ5oUAViCFJMB0GA1UdDgQW
+BBRLvvp2hCNEBLnOvjFv6fUyBv8MVzAOBgNVHQ8BAf8EBAMCAYYwEgYDVR0TAQH/
+BAgwBgEB/wIBADATBgNVHSUEDDAKBggrBgEFBQcDATATBgNVHSAEDDAKMAgGBmeB
+DAECATBUBgNVHR8ETTBLMEmgR6BFhkNodHRwOi8vY3JsLnNlY3RpZ28uY29tL1Nl
+Y3RpZ29QdWJsaWNTZXJ2ZXJBdXRoZW50aWNhdGlvblJvb3RSNDYuY3JsMIGEBggr
+BgEFBQcBAQR4MHYwTwYIKwYBBQUHMAKGQ2h0dHA6Ly9jcnQuc2VjdGlnby5jb20v
+U2VjdGlnb1B1YmxpY1NlcnZlckF1dGhlbnRpY2F0aW9uUm9vdFI0Ni5wN2MwIwYI
+KwYBBQUHMAGGF2h0dHA6Ly9vY3NwLnNlY3RpZ28uY29tMA0GCSqGSIb3DQEBDAUA
+A4ICAQCJ/3v2/vdexHsdVyXL9aCTQE01YXl23866TVM/LgRpRW+kneZXXZxP0hy4
+GnvlqUcxTq97B6qPdQcQxQxpGne7CRn0nWauzqieMcJzYl3fDC2Q/ANyPhyrbwCI
+zx9EsRrgfjvuJCaUMtlfYpKqBUYiPOCPAN0HdrLD5hU6oV1tvWVsUzTA43skC3uH
+wQM5YPIk0NDJFw3NhQPOIOwbq09T+SYSEZvsJ3t4sA4H3gh03RETNaAwTcTNS/+u
+1tAeQUZZmKQyLWYLyoxvbISp/MFr9xqhDqrpAurYVNeiLJ5+4/WZPml20yNZjcxV
+KKqRYdEurl8rmI2toCnCDWiEcTDvoYGtz60eYIt7VJID4DrCjTxAWTWh2T5ag2pK
+ryNJGt8BFGLtjeD774SxAFn5MGYBVvEK4LXmCjVX78pb6/0Dceo71dlQUK68yftb
++yTeyoqjwgk2L8vNSrkj6UTkvvqXSONFuVU7bvC0O/9bi5MXBv7QUivMNxDsTtaT
+IZO7PsSCRmLraQM2EPBgbNL9lRSEYi4Hj+NicT/e87pbhv88k0oec9xGcnkcvZpN
+sJBz78mkZfeFIIjh02e2y9ke/Fqw1FbdhHtU2myaFnX0sRyGLmI/vzXSwyvT+Kxl
+Wx8FV64z2PBdwd0vXRaAMXomGC0M1vQa5fBDn4dimzewsSiphQ==
+-----END CERTIFICATE-----`
+
+// Combine system root CAs with the missing intermediate cert
+const caCerts = [...tls.rootCertificates, ZEROSSL_INTERMEDIATE_CA]
+
+export interface CloudDeviceConfig {
+    serialNumber: string
+    pin: string
+}
+
+// Messages exchanged with the my.enervent.com backend. Only the fields we actually use are typed.
+// These ride on Socket.IO "message" packets, i.e. socket.send() / the "message" event.
+
+interface SocketIoMessage {
+    type?: string
+    dst?: string | null
+    data?: unknown
+    _id?: number
+    _ack?: number
+    // Handed out with the login ack; every later message has to echo it back
+    sessid?: string
+}
+
+// Both the initial dump and subsequent change notifications carry parallel register/value arrays
+interface UcpRegisterData {
+    type?: string
+    registers?: number[]
+    data?: number[]
+}
+
+interface AuthResponse {
+    login?: string
+    mac?: string
+}
+
+type AckCallback = (payload: unknown) => void
+
+// How long to wait without register changes before reconnecting (in milliseconds)
+const CHANGES_TIMEOUT_MS = 60000
+// How often to check for stale connections (in milliseconds)
+const HEALTH_CHECK_INTERVAL_MS = 15000
+// How long to wait for the initial socket connection (in milliseconds)
+const CONNECT_TIMEOUT_MS = 20000
+// How long to wait for the login response (in milliseconds)
+const AUTH_TIMEOUT_MS = 30000
+// How long to give the backend to deliver the register dump (in milliseconds)
+const DUMP_WAIT_MS = 5000
+// How long to wait for a write to be acknowledged (in milliseconds)
+const WRITE_TIMEOUT_MS = 10000
+// How long to wait for the device model (in milliseconds)
+const MODEL_WAIT_MS = 15000
+// Coils live above this address in the cloud's flat feature space
+const COIL_ADDRESS_OFFSET = 10000
+// How long to wait for the unit to stream the coil block (in milliseconds)
+const COIL_WAIT_MS = 20000
+// How long to let the coil block finish arriving once it starts (in milliseconds)
+const COIL_SETTLE_MS = 1500
+
+interface WriteResponse {
+    error?: unknown
+}
+
+// The backend describes the device with `{type:'command', command:'model'}` - a list of feature
+// descriptors, each carrying its Modbus register (`mbreg`, already 10000+ for coils), an access
+// flag and bounds. That is the authority on what may be written: RO and NA registers are refused,
+// and values are checked against the device's own limits rather than anything hardcoded here.
+
+interface ModelItem {
+    mbreg?: string
+    access?: string
+    bounds?: string
+    symbol?: string
+}
+
+interface DeviceModel {
+    items?: ModelItem[]
+}
+
+// The model's access flags are not always right. COIL_M_BOOST is reported NA, yet writing it works
+// and the unit echoes the new value back within half a second - verified against the device on
+// 2026-09-06. Anything listed here is treated as writable regardless of what the model claims, so
+// only add a register after confirming the unit really does apply a write to it.
+const ACCESS_OVERRIDES: ReadonlyMap<number, string> = new Map<number, string>([
+    [10010, 'RW'], // COIL_M_BOOST, manual boost
+])
+
+interface RegisterInfo {
+    access: string
+    symbol: string
+    min?: number
+    max?: number
+}
+
+export class EnerventCloudClient implements ModbusClient {
+    private socket: Socket | null = null
+    private deviceMac: string | null = null
+    private registers: Map<number, number> = new Map()
+    private config: CloudDeviceConfig
+    private ackId: number = 1
+    private ackCallbacks: Map<number, AckCallback> = new Map()
+    private healthCheckInterval: ReturnType<typeof setInterval> | null = null
+    private lastChangesTime: number = Date.now()
+    private sessionEstablished: boolean = false
+    private sessionId: string | null = null
+    private pendingWrites: Map<number, { value: number; resolve: () => void }> = new Map()
+    private registerInfo: Map<number, RegisterInfo> = new Map()
+    private modelResolve: (() => void) | null = null
+    private coilSpaceResolve: (() => void) | null = null
+
+    constructor(config: CloudDeviceConfig) {
+        this.config = config
+    }
+
+    async connect(): Promise<void> {
+        logger.info(`Connecting to Enervent cloud for device ${this.config.serialNumber}...`)
+
+        const socket = io(MY_ENERVENT_URL, {
+            // The server only sends its leaf certificate, so a custom CA list is required. Sticking
+            // to the WebSocket transport also skips the HTTP polling handshake entirely.
+            transports: ['websocket'],
+            ca: caCerts,
+            timeout: CONNECT_TIMEOUT_MS,
+            reconnectionDelay: 5000,
+            reconnectionDelayMax: 60000,
+        })
+        this.socket = socket
+
+        socket.on('message', (raw: unknown) => {
+            this.handleMessage(raw)
+        })
+
+        socket.on('disconnect', (reason) => {
+            logger.warn(`Disconnected from Enervent cloud: ${reason}`)
+        })
+
+        socket.io.on('reconnect_attempt', (attempt) => {
+            logger.info(`Reconnecting to Enervent cloud (attempt ${attempt})...`)
+        })
+
+        // The backend keeps no state for us across sockets, so every reconnection needs a fresh
+        // login and dump. The initial connection is driven by this method instead.
+        socket.on('connect', () => {
+            if (!this.sessionEstablished) {
+                return
+            }
+
+            logger.info('Reconnected, re-establishing session...')
+            this.establishSession().catch((error) => {
+                logger.error(`Failed to re-establish session: ${String(error)}`)
+            })
+        })
+
+        // Surface anything the backend sends that we don't handle yet
+        socket.onAny((event: string, ...args: unknown[]) => {
+            if (event !== 'message') {
+                logger.debug(`Unhandled event "${event}": ${JSON.stringify(args).slice(0, 500)}`)
+            }
+        })
+
+        await new Promise<void>((resolve, reject) => {
+            socket.once('connect', () => resolve())
+            socket.once('connect_error', (error: Error) => reject(error))
+        })
+
+        logger.info('Connected to Enervent cloud')
+
+        await this.establishSession()
+        this.sessionEstablished = true
+        this.startHealthCheck()
+    }
+
+    private async establishSession(): Promise<void> {
+        this.sessionId = null
+        await this.authenticate()
+        await this.requestModel()
+        await this.requestDump()
+        this.lastChangesTime = Date.now()
+    }
+
+    private async authenticate(): Promise<void> {
+        logger.info(`Authenticating with serial number ${this.config.serialNumber}...`)
+
+        const payload = await this.sendEventWithAck(
+            {
+                type: 'backend',
+                data: {
+                    type: 'auth',
+                    cmd: 'loginWithPin',
+                    serialnumber: this.config.serialNumber,
+                    pin: this.config.pin,
+                },
+            },
+            AUTH_TIMEOUT_MS,
+            'Authentication timeout'
+        )
+
+        const response = payload as AuthResponse
+
+        if (response.login !== 'ok') {
+            throw new Error(`Authentication failed: ${JSON.stringify(payload)}`)
+        }
+
+        this.deviceMac = response.mac ?? null
+        logger.info(`Authenticated successfully, device MAC: ${this.deviceMac}`)
+    }
+
+    private requestModel(): Promise<void> {
+        logger.info('Requesting device model...')
+
+        return new Promise((resolve) => {
+            const timeout = setTimeout(() => {
+                this.modelResolve = null
+                logger.warn('No device model received, writes will not be validated against it')
+                resolve()
+            }, MODEL_WAIT_MS)
+
+            this.modelResolve = () => {
+                clearTimeout(timeout)
+                this.modelResolve = null
+                resolve()
+            }
+
+            this.sendEvent({
+                type: 'ucp',
+                dst: this.deviceMac,
+                data: { type: 'command', command: 'model' },
+            })
+        })
+    }
+
+    private parseModel(model: DeviceModel): void {
+        this.registerInfo.clear()
+
+        for (const item of model.items ?? []) {
+            const address = Number.parseInt(item.mbreg ?? '', 10)
+
+            if (Number.isNaN(address)) {
+                continue
+            }
+
+            const [min, max] = (item.bounds ?? '').split(',').map((bound) => Number.parseInt(bound, 10))
+
+            this.registerInfo.set(address, {
+                access: item.access ?? 'NA',
+                symbol: item.symbol ?? '',
+                min: Number.isNaN(min) ? undefined : min,
+                max: Number.isNaN(max) ? undefined : max,
+            })
+        }
+
+        const writable = [...this.registerInfo.values()].filter((info) => info.access === 'RW').length
+        logger.info(`Device model describes ${this.registerInfo.size} registers, ${writable} of them writable`)
+
+        this.modelResolve?.()
+    }
+
+    private async requestDump(): Promise<void> {
+        logger.info('Requesting register dump...')
+
+        this.sendEvent({
+            type: 'ucp',
+            dst: this.deviceMac,
+            data: { type: 'command', command: 'dump' },
+        })
+
+        // Give some time for dump to arrive
+        await this.delay(DUMP_WAIT_MS)
+        logger.info(`Received ${this.registers.size} registers from dump`)
+
+        await this.waitForCoilSpace()
+    }
+
+    // Coils are not part of the dump payload: the unit streams them as changes a few seconds
+    // afterwards. Without waiting for them every coil reads as 0, so the first publish would report
+    // every mode and switch as off before correcting itself on the next cycle.
+    private async waitForCoilSpace(): Promise<void> {
+        const alreadyPresent = [...this.registers.keys()].some((address) => address >= COIL_ADDRESS_OFFSET)
+
+        if (!alreadyPresent) {
+            await new Promise<void>((resolve) => {
+                const timeout = setTimeout(() => {
+                    this.coilSpaceResolve = null
+                    logger.warn(
+                        'No coil values received, mode and switch states may be wrong until the unit reports them'
+                    )
+                    resolve()
+                }, COIL_WAIT_MS)
+
+                this.coilSpaceResolve = () => {
+                    clearTimeout(timeout)
+                    this.coilSpaceResolve = null
+                    resolve()
+                }
+            })
+
+            // The block arrives in quick succession; let the rest of it land
+            await this.delay(COIL_SETTLE_MS)
+        }
+
+        const coils = [...this.registers.keys()].filter((address) => address >= COIL_ADDRESS_OFFSET).length
+        logger.info(`Received ${coils} coil values`)
+    }
+
+    private delay(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms))
+    }
+
+    private startHealthCheck(): void {
+        this.lastChangesTime = Date.now()
+
+        this.healthCheckInterval = setInterval(() => {
+            const timeSinceLastChanges = Date.now() - this.lastChangesTime
+            if (timeSinceLastChanges <= CHANGES_TIMEOUT_MS) {
+                return
+            }
+
+            // The socket can stay open while the backend silently stops pushing, so incoming data
+            // is the only reliable liveness signal. Bounce the connection and let socket.io handle
+            // the retry schedule. Reset the timer so this doesn't fire again while it reconnects.
+            logger.warn(
+                `No register changes received in ${Math.round(timeSinceLastChanges / 1000)} seconds, reconnecting...`
+            )
+            this.lastChangesTime = Date.now()
+            this.socket?.disconnect().connect()
+        }, HEALTH_CHECK_INTERVAL_MS)
+    }
+
+    private handleMessage(raw: unknown): void {
+        // The backend sends JSON strings over the "message" event rather than objects
+        let payload: SocketIoMessage
+
+        try {
+            payload = typeof raw === 'string' ? (JSON.parse(raw) as SocketIoMessage) : (raw as SocketIoMessage)
+        } catch (e) {
+            logger.warn(`Failed to parse message payload: ${String(e)}`)
+            return
+        }
+
+        this.handlePayload(payload)
+    }
+
+    private handlePayload(payload: SocketIoMessage): void {
+        const modelData = payload.data as { model?: DeviceModel } | undefined
+
+        if (modelData?.model !== undefined) {
+            this.parseModel(modelData.model)
+        }
+
+        // The login ack carries a session ID that every subsequent message must repeat
+        if (payload.sessid) {
+            this.sessionId = payload.sessid
+        }
+
+        const ucpData = payload.type === 'ucp' ? (payload.data as UcpRegisterData | undefined) : undefined
+
+        // Handle UCP messages with register changes
+        if (ucpData?.type === 'changes') {
+            this.lastChangesTime = Date.now()
+
+            const registers = ucpData.registers ?? []
+            const values = ucpData.data ?? []
+
+            registers.forEach((register, index) => {
+                const oldValue = this.registers.get(register)
+                this.registers.set(register, values[index])
+                if (oldValue !== values[index] && register !== 789) {
+                    logger.debug(`Register ${register}: ${oldValue} -> ${values[index]}`)
+                }
+
+                if (register >= COIL_ADDRESS_OFFSET) {
+                    this.coilSpaceResolve?.()
+                }
+
+                // A write is confirmed once the unit echoes the new value back to us
+                const pending = this.pendingWrites.get(register)
+                if (pending !== undefined && pending.value === values[index]) {
+                    pending.resolve()
+                }
+            })
+        }
+
+        // Handle UCP messages with dump data
+        if (ucpData?.type === 'dump') {
+            const registers = ucpData.registers ?? []
+            const values = ucpData.data ?? []
+
+            registers.forEach((register, index) => {
+                this.registers.set(register, values[index])
+            })
+
+            logger.debug(`Dump received: ${registers.length} registers`)
+        }
+
+        // Handle ack callbacks
+        if (payload._ack !== undefined) {
+            const callback = this.ackCallbacks.get(payload._ack)
+            if (callback) {
+                callback(payload.data)
+                this.ackCallbacks.delete(payload._ack)
+            }
+        }
+    }
+
+    // Resolves once the unit reports the register holding the given value on the changes stream
+    private waitForRegisterValue(address: number, value: number, timeoutMs: number): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.pendingWrites.delete(address)
+                reject(new Error(`Timed out waiting for register ${address} to become ${value}`))
+            }, timeoutMs)
+
+            this.pendingWrites.set(address, {
+                value,
+                resolve: () => {
+                    clearTimeout(timeout)
+                    this.pendingWrites.delete(address)
+                    resolve()
+                },
+            })
+        })
+    }
+
+    private sendEvent(payload: SocketIoMessage): void {
+        if (!this.socket) {
+            logger.warn('Not connected to Enervent cloud, dropping outgoing message')
+            return
+        }
+
+        const message: SocketIoMessage = this.sessionId !== null ? { ...payload, sessid: this.sessionId } : payload
+        // The backend expects a serialized payload, not an object. Deliberately not logged: the
+        // login frame carries the PIN in cleartext.
+        this.socket.send(JSON.stringify(message))
+    }
+
+    // Sends a payload and resolves with the backend's reply, correlated by the application-level
+    // _id/_ack pair. Drops the pending callback if the reply never arrives.
+    private sendEventWithAck(payload: SocketIoMessage, timeoutMs: number, timeoutMessage: string): Promise<unknown> {
+        return new Promise((resolve, reject) => {
+            const ackId = this.ackId++
+
+            const timeout = setTimeout(() => {
+                this.ackCallbacks.delete(ackId)
+                reject(new Error(timeoutMessage))
+            }, timeoutMs)
+
+            this.ackCallbacks.set(ackId, (response: unknown) => {
+                clearTimeout(timeout)
+                resolve(response)
+            })
+
+            this.sendEvent({ ...payload, _id: ackId })
+        })
+    }
+
+    async readCoils(address: number, length: number): Promise<CoilResult> {
+        const registers = await this.readHoldingRegisters(COIL_ADDRESS_OFFSET + address, length)
+        const data = registers.data.map((value) => value === 1)
+
+        logger.debug(`readCoils(${address}, ${length}) => ${JSON.stringify(data)}`)
+        return { data }
+    }
+
+    async writeCoil(address: number, value: boolean): Promise<void> {
+        logger.debug(`writeCoil(${address}, ${value})`)
+        // The coils seem to be on 10000+ addresses
+        await this.writeRegister(COIL_ADDRESS_OFFSET + address, value ? 1 : 0)
+    }
+
+    // Reads are served from the local register cache, so no round trip to the cloud is needed
+    readHoldingRegisters(address: number, length: number): Promise<RegisterResult> {
+        const data: number[] = []
+
+        for (let i = 0; i < length; i++) {
+            const regAddress = address + i
+            const value = this.registers.get(regAddress) ?? 0
+            data.push(value)
+        }
+
+        logger.debug(`readHoldingRegisters(${address}, ${length}) => ${JSON.stringify(data)}`)
+        return Promise.resolve({ data })
+    }
+
+    async writeRegister(address: number, value: number): Promise<void> {
+        const info = this.registerInfo.get(address)
+        const label = info?.symbol !== undefined && info.symbol !== '' ? info.symbol : `register ${address}`
+
+        // Refusals are our own decision rather than a device failure, so they resolve instead of
+        // rejecting: repeated rejections would trip the ErrorHandler's subsequent error limit and
+        // bring the bridge down. Leaving the cache untouched means the next publish cycle reverts
+        // the change in Home Assistant on its own.
+        if (info === undefined) {
+            logger.warn(`Refusing to write ${value} to register ${address}: not described by the device model`)
+            return
+        }
+
+        const access = ACCESS_OVERRIDES.get(address) ?? info.access
+
+        if (access !== 'RW') {
+            logger.warn(`Refusing to write ${value} to ${label} (${address}): the device reports it as ${info.access}`)
+            return
+        }
+
+        if ((info.min !== undefined && value < info.min) || (info.max !== undefined && value > info.max)) {
+            logger.warn(
+                `Refusing to write ${value} to ${label} (${address}): outside the device's bounds ${info.min}-${info.max}`
+            )
+            return
+        }
+
+        // Writing a value the unit already holds produces no changes notification, so there would
+        // be nothing to confirm against.
+        if (this.registers.get(address) === value) {
+            logger.debug(`${label} (${address}) already holds ${value}, skipping write`)
+            return
+        }
+
+        const oldValue = this.registers.get(address)
+        logger.info(`writeRegister(${address}) [${label}]: ${oldValue} -> ${value}`)
+
+        // The unit echoing the new value back is the authoritative confirmation. Holding register
+        // writes are also acknowledged, but coil writes are not - waiting on the ack alone would
+        // fail every mode and switch write even though the device applies them.
+        const confirmation = this.waitForRegisterValue(address, value, WRITE_TIMEOUT_MS)
+
+        // Still send with an ack so that an explicit backend error surfaces
+        this.sendEventWithAck(
+            {
+                type: 'ucp',
+                dst: this.deviceMac,
+                data: {
+                    type: 'command',
+                    command: 'write',
+                    id: address,
+                    value,
+                },
+            },
+            WRITE_TIMEOUT_MS,
+            `No acknowledgement for write to register ${address}`
+        )
+            .then((payload) => {
+                const response = (payload ?? {}) as WriteResponse
+
+                if (response.error !== undefined) {
+                    logger.error(
+                        `Backend reported an error writing ${label} (${address}): ${JSON.stringify(response.error)}`
+                    )
+                }
+            })
+            .catch(() => {
+                // Coil writes are never acknowledged; the changes stream is what confirms them
+            })
+
+        await confirmation
+    }
+
+    disconnect(): void {
+        if (this.healthCheckInterval) {
+            clearInterval(this.healthCheckInterval)
+            this.healthCheckInterval = null
+        }
+        if (this.socket) {
+            this.socket.disconnect()
+            this.socket = null
+        }
+    }
+}

--- a/app/enervent.ts
+++ b/app/enervent.ts
@@ -1,4 +1,4 @@
-import { ReadRegisterResult } from 'modbus-serial/ModbusRTU'
+import type { RegisterResult } from './client'
 
 export const AVAILABLE_MODES: Record<string, number> = {
     'away': 1,
@@ -318,7 +318,7 @@ export const createModelNameString = (deviceInformation: Partial<DeviceInformati
     return modelName
 }
 
-export const parseAlarmTimestamp = (result: ReadRegisterResult) => {
+export const parseAlarmTimestamp = (result: RegisterResult) => {
     return new Date(result.data[2] + 2000, result.data[3] - 1, result.data[4], result.data[5], result.data[6])
 }
 
@@ -344,7 +344,7 @@ export const parseStateBitField = (state: number) => {
     }
 }
 
-export const hasRoomTemperatureSensor = (sensorTypesResult: ReadRegisterResult): boolean => {
+export const hasRoomTemperatureSensor = (sensorTypesResult: RegisterResult): boolean => {
     for (let i = 0; i < 6; i++) {
         const sensor = ANALOG_INPUT_SENSOR_TYPES.find((sensor) => sensor.type === sensorTypesResult.data[i])
 
@@ -357,8 +357,8 @@ export const hasRoomTemperatureSensor = (sensorTypesResult: ReadRegisterResult):
 }
 
 export const parseAnalogSensors = (
-    sensorTypesResult: ReadRegisterResult,
-    sensorValuesResult: ReadRegisterResult
+    sensorTypesResult: RegisterResult,
+    sensorValuesResult: RegisterResult
 ): AnalogSensorReadings => {
     const sensorReadings: AnalogSensorReadings = {}
 

--- a/app/homeassistant.ts
+++ b/app/homeassistant.ts
@@ -17,7 +17,7 @@ import {
     DeviceInformation,
     getTemperatureControlStateValues,
 } from './enervent'
-import ModbusRTU from 'modbus-serial'
+import type { ModbusClient } from './client'
 import { MqttClient } from 'mqtt'
 
 type EntityConfiguration = {
@@ -26,7 +26,7 @@ type EntityConfiguration = {
 
 const logger = createLogger('homeassistant')
 
-export const configureMqttDiscovery = async (modbusClient: ModbusRTU, mqttClient: MqttClient) => {
+export const configureMqttDiscovery = async (modbusClient: ModbusClient, mqttClient: MqttClient) => {
     // Build information about the ventilation unit. The "deviceIdentifier" is used as <node_id> in discovery topic
     // names, so it must match [a-zA-Z0-9_-].
     const modbusDeviceInformation = await getDeviceInformation(modbusClient)

--- a/app/http.ts
+++ b/app/http.ts
@@ -13,7 +13,7 @@ import {
 } from './modbus'
 import { createLogger } from './logger'
 import { Express, Request, Response } from 'express'
-import ModbusRTU from 'modbus-serial'
+import type { ModbusClient } from './client'
 
 const logger = createLogger('http')
 
@@ -21,7 +21,7 @@ const root = (req: Request, res: Response) => {
     res.send('eda-modbus-bridge')
 }
 
-const summary = async (modbusClient: ModbusRTU, req: Request, res: Response) => {
+const summary = async (modbusClient: ModbusClient, req: Request, res: Response) => {
     try {
         const modeSummary = await getModeSummary(modbusClient)
         const newestAlarm = await getNewestAlarm(modbusClient)
@@ -42,7 +42,7 @@ const summary = async (modbusClient: ModbusRTU, req: Request, res: Response) => 
     }
 }
 
-const getMode = async (modbusClient: ModbusRTU, req: Request, res: Response) => {
+const getMode = async (modbusClient: ModbusClient, req: Request, res: Response) => {
     try {
         const mode = req.params['mode']
         const status = await modbusGetMode(modbusClient, mode)
@@ -55,7 +55,7 @@ const getMode = async (modbusClient: ModbusRTU, req: Request, res: Response) => 
     }
 }
 
-const setMode = async (modbusClient: ModbusRTU, req: Request, res: Response) => {
+const setMode = async (modbusClient: ModbusClient, req: Request, res: Response) => {
     try {
         const mode = req.params['mode']
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -73,7 +73,7 @@ const setMode = async (modbusClient: ModbusRTU, req: Request, res: Response) => 
     }
 }
 
-const setSetting = async (modbusClient: ModbusRTU, req: Request, res: Response) => {
+const setSetting = async (modbusClient: ModbusClient, req: Request, res: Response) => {
     try {
         const setting = req.params['setting']
         const value = req.params['value']
@@ -94,7 +94,7 @@ const setSetting = async (modbusClient: ModbusRTU, req: Request, res: Response) 
     }
 }
 
-const acknowledgeAlarm = async (modbusClient: ModbusRTU, req: Request, res: Response) => {
+const acknowledgeAlarm = async (modbusClient: ModbusClient, req: Request, res: Response) => {
     try {
         logger.info('Acknowledging currently active alarm (if any)')
 
@@ -104,7 +104,7 @@ const acknowledgeAlarm = async (modbusClient: ModbusRTU, req: Request, res: Resp
     }
 }
 
-export const configureRoutes = (httpServer: Express, modbusClient: ModbusRTU) => {
+export const configureRoutes = (httpServer: Express, modbusClient: ModbusClient) => {
     /* eslint-disable @typescript-eslint/no-misused-promises */
     httpServer.get('/', root)
     httpServer.get('/summary', (req, res) => {

--- a/app/modbus.ts
+++ b/app/modbus.ts
@@ -25,34 +25,40 @@ import {
     CoilSettingConfiguration,
     HoldingRegisterSettingConfiguration,
 } from './enervent'
-import ModbusRTU from 'modbus-serial'
-import { ReadCoilResult, ReadRegisterResult } from 'modbus-serial/ModbusRTU'
+import type { CoilResult, ModbusClient, RegisterResult } from './client'
 
 export enum ModbusDeviceType {
     RTU = 'RTU',
     TCP = 'TCP',
+    CLOUD = 'CLOUD',
 }
 
 export type ModbusRtuDevice = {
-    type: ModbusDeviceType
+    type: ModbusDeviceType.RTU
     path: string
 }
 
 export type ModbusTcpDevice = {
-    type: ModbusDeviceType
+    type: ModbusDeviceType.TCP
     hostname: string
     port: number
 }
 
-export type ModbusDevice = ModbusRtuDevice | ModbusTcpDevice
+export type ModbusCloudDevice = {
+    type: ModbusDeviceType.CLOUD
+    serialNumber: string
+    pin: string
+}
+
+export type ModbusDevice = ModbusRtuDevice | ModbusTcpDevice | ModbusCloudDevice
 
 const mutex = new Mutex()
 const logger = createLogger('modbus')
 
 // Runtime cache for device information (retrieved once per run only since the information doesn't change)
-let CACHED_DEVICE_INFORMATION: DeviceInformation
+let CACHED_DEVICE_INFORMATION: DeviceInformation | undefined
 
-export const getModeSummary = async (modbusClient: ModbusRTU): Promise<ModeSummary> => {
+export const getModeSummary = async (modbusClient: ModbusClient): Promise<ModeSummary> => {
     let result = await mutex.runExclusive(async () => tryReadCoils(modbusClient, 0, 13))
     let summary: ModeSummary = {
         // 'stop': result.data[0], // - Can not return value if stopped.
@@ -77,7 +83,7 @@ export const getModeSummary = async (modbusClient: ModbusRTU): Promise<ModeSumma
     return summary
 }
 
-export const getMode = async (modbusClient: ModbusRTU, mode: string) => {
+export const getMode = async (modbusClient: ModbusClient, mode: string) => {
     if (AVAILABLE_MODES[mode] === undefined) {
         throw new Error('Unknown mode')
     }
@@ -87,7 +93,7 @@ export const getMode = async (modbusClient: ModbusRTU, mode: string) => {
     return result.data[0]
 }
 
-export const setMode = async (modbusClient: ModbusRTU, mode: string, value: boolean) => {
+export const setMode = async (modbusClient: ModbusClient, mode: string, value: boolean) => {
     if (AVAILABLE_MODES[mode] === undefined) {
         throw new Error('Unknown mode')
     }
@@ -100,7 +106,7 @@ export const setMode = async (modbusClient: ModbusRTU, mode: string, value: bool
     }
 }
 
-const disableAllModesExcept = async (modbusClient: ModbusRTU, exceptedMode: string) => {
+const disableAllModesExcept = async (modbusClient: ModbusClient, exceptedMode: string) => {
     for (const mode in AVAILABLE_MODES) {
         if (mode === exceptedMode) {
             continue
@@ -110,7 +116,7 @@ const disableAllModesExcept = async (modbusClient: ModbusRTU, exceptedMode: stri
     }
 }
 
-export const getReadings = async (modbusClient: ModbusRTU): Promise<Readings> => {
+export const getReadings = async (modbusClient: ModbusClient): Promise<Readings> => {
     logger.debug('Retrieving device readings...')
 
     let result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 6, 8))
@@ -207,10 +213,10 @@ export const getReadings = async (modbusClient: ModbusRTU): Promise<Readings> =>
     return readings as Readings
 }
 
-export const getSettings = async (modbusClient: ModbusRTU): Promise<Settings> => {
+export const getSettings = async (modbusClient: ModbusClient): Promise<Settings> => {
     logger.debug('Retrieving device settings...')
 
-    let result: ReadRegisterResult | ReadCoilResult
+    let result: RegisterResult | CoilResult
 
     result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 57, 1))
     let settings: Partial<Settings> = {
@@ -297,7 +303,7 @@ const parseSettingValue = (settingConfig: HoldingRegisterSettingConfiguration, v
     }
 }
 
-export const setSetting = async (modbusClient: ModbusRTU, setting: string, value: string | boolean) => {
+export const setSetting = async (modbusClient: ModbusClient, setting: string, value: string | boolean) => {
     const settingConfig = AVAILABLE_SETTINGS[setting]
     if (settingConfig === undefined) {
         throw new Error(`Unknown setting "${setting}"`)
@@ -323,7 +329,7 @@ export const setSetting = async (modbusClient: ModbusRTU, setting: string, value
 }
 
 const setBooleanSetting = async (
-    modbusClient: ModbusRTU,
+    modbusClient: ModbusClient,
     settingConfig: CoilSettingConfiguration,
     boolValue: boolean
 ) => {
@@ -331,7 +337,7 @@ const setBooleanSetting = async (
 }
 
 const setNumericSetting = async (
-    modbusClient: ModbusRTU,
+    modbusClient: ModbusClient,
     settingConfig: HoldingRegisterSettingConfiguration,
     numericValue: number
 ) => {
@@ -349,17 +355,24 @@ const setNumericSetting = async (
     await mutex.runExclusive(async () => tryWriteHoldingRegister(modbusClient, settingConfig.dataAddress, scaledValue))
 }
 
-export const getDeviceInformation = async (modbusClient: ModbusRTU): Promise<DeviceInformation> => {
+export const getDeviceInformation = async (modbusClient: ModbusClient): Promise<DeviceInformation> => {
     if (CACHED_DEVICE_INFORMATION) {
         return CACHED_DEVICE_INFORMATION
     }
 
     logger.debug('Retrieving device information...')
 
-    let result: ReadRegisterResult | ReadCoilResult
+    let result: RegisterResult | CoilResult
 
     // Start by reading the firmware version and determining the firmware type
     result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 599, 1))
+
+    // A cloud connection answers 0 for registers it never received. Identifying the device from
+    // that would cache a bogus model, firmware version and automation type for the rest of the run.
+    if (result.data[0] === 0) {
+        throw new Error('Device reported no software version, refusing to identify it')
+    }
+
     let deviceInformation: Partial<DeviceInformation> = {
         'softwareVersion': result.data[0] / 100,
         'automationType': determineAutomationType(result.data[0]),
@@ -407,7 +420,12 @@ export const getDeviceInformation = async (modbusClient: ModbusRTU): Promise<Dev
     return deviceInformation as DeviceInformation
 }
 
-export const getAlarmSummary = async (modbusClient: ModbusRTU): Promise<AlarmStatus[]> => {
+// The device cannot change while the process runs, so only the tests need this
+export const resetDeviceInformationCache = () => {
+    CACHED_DEVICE_INFORMATION = undefined
+}
+
+export const getAlarmSummary = async (modbusClient: ModbusClient): Promise<AlarmStatus[]> => {
     const alarmSummary: AlarmStatus[] = []
     const newestAlarm = await getNewestAlarm(modbusClient)
 
@@ -422,7 +440,7 @@ export const getAlarmSummary = async (modbusClient: ModbusRTU): Promise<AlarmSta
     return alarmSummary
 }
 
-export const getNewestAlarm = async (modbusClient: ModbusRTU): Promise<AlarmIncident | null> => {
+export const getNewestAlarm = async (modbusClient: ModbusClient): Promise<AlarmIncident | null> => {
     const result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 385, 7))
 
     const type = result.data[0]
@@ -441,18 +459,35 @@ export const getNewestAlarm = async (modbusClient: ModbusRTU): Promise<AlarmInci
     }
 }
 
-export const acknowledgeAlarm = async (modbusClient: ModbusRTU) => {
+export const acknowledgeAlarm = async (modbusClient: ModbusClient) => {
     await tryWriteHoldingRegister(modbusClient, 386, 1)
 }
 
-export const getDeviceState = async (modbusClient: ModbusRTU) => {
+export const getDeviceState = async (modbusClient: ModbusClient) => {
     const result = await mutex.runExclusive(async () => tryReadHoldingRegisters(modbusClient, 44, 1))
 
     return parseStateBitField(result.data[0])
 }
 
 export const validateDevice = (device: string) => {
+    if (device.startsWith('cloud://')) {
+        const parts = device.substring(8).split(':')
+
+        return parts.length === 2 && parts[0] !== '' && parts[1] !== ''
+    }
+
     return device.startsWith('/') || device.startsWith('tcp://')
+}
+
+// A cloud device string carries the PIN, which must never reach the logs
+export const redactDevice = (device: string) => {
+    if (!device.startsWith('cloud://')) {
+        return device
+    }
+
+    const [serialNumber] = device.substring(8).split(':')
+
+    return `cloud://${serialNumber}:<redacted>`
 }
 
 export const parseDevice = (device: string): ModbusDevice => {
@@ -461,6 +496,14 @@ export const parseDevice = (device: string): ModbusDevice => {
         return {
             type: ModbusDeviceType.RTU,
             path: device,
+        }
+    } else if (device.startsWith('cloud://')) {
+        // Cloud connection: cloud://serialnumber:pin
+        const parts = device.substring(8).split(':')
+        return {
+            type: ModbusDeviceType.CLOUD,
+            serialNumber: parts[0],
+            pin: parts[1],
         }
     } else {
         // TCP URL
@@ -473,7 +516,7 @@ export const parseDevice = (device: string): ModbusDevice => {
     }
 }
 
-const tryReadCoils = async (modbusClient: ModbusRTU, dataAddress: number, length: number) => {
+const tryReadCoils = async (modbusClient: ModbusClient, dataAddress: number, length: number) => {
     try {
         logger.debug(`Reading coil address ${dataAddress}, length ${length}`)
         return await modbusClient.readCoils(dataAddress, length)
@@ -483,7 +526,7 @@ const tryReadCoils = async (modbusClient: ModbusRTU, dataAddress: number, length
     }
 }
 
-const tryWriteCoil = async (modbusClient: ModbusRTU, dataAddress: number, value: boolean) => {
+const tryWriteCoil = async (modbusClient: ModbusClient, dataAddress: number, value: boolean) => {
     try {
         logger.debug(`Writing ${value} to coil address ${dataAddress}`)
         return await modbusClient.writeCoil(dataAddress, value)
@@ -493,7 +536,7 @@ const tryWriteCoil = async (modbusClient: ModbusRTU, dataAddress: number, value:
     }
 }
 
-const tryReadHoldingRegisters = async (modbusClient: ModbusRTU, dataAddress: number, length: number) => {
+const tryReadHoldingRegisters = async (modbusClient: ModbusClient, dataAddress: number, length: number) => {
     try {
         logger.debug(`Reading holding register address ${dataAddress}, length ${length}`)
         return await modbusClient.readHoldingRegisters(dataAddress, length)
@@ -503,7 +546,7 @@ const tryReadHoldingRegisters = async (modbusClient: ModbusRTU, dataAddress: num
     }
 }
 
-const tryWriteHoldingRegister = async (modbusClient: ModbusRTU, dataAddress: number, value: number) => {
+const tryWriteHoldingRegister = async (modbusClient: ModbusClient, dataAddress: number, value: number) => {
     try {
         logger.debug(`Writing ${value} to holding register address ${dataAddress}`)
         return await modbusClient.writeRegister(dataAddress, value)

--- a/app/mqtt.ts
+++ b/app/mqtt.ts
@@ -10,7 +10,7 @@ import {
     acknowledgeAlarm,
 } from './modbus'
 import { createLogger } from './logger'
-import ModbusRTU from 'modbus-serial'
+import type { ModbusClient } from './client'
 import { MqttClient } from 'mqtt'
 
 export const TOPIC_PREFIX = 'eda'
@@ -27,7 +27,7 @@ type TopicMap = Record<string, TopicValue>
 
 const logger = createLogger('mqtt')
 
-export const publishValues = async (modbusClient: ModbusRTU, mqttClient: MqttClient) => {
+export const publishValues = async (modbusClient: ModbusClient, mqttClient: MqttClient) => {
     // Create a map from topic name to value that should be published
     const topicMap: TopicMap = {
         [TOPIC_NAME_STATUS]: 'online',
@@ -68,7 +68,7 @@ export const publishValues = async (modbusClient: ModbusRTU, mqttClient: MqttCli
     await publishTopics(mqttClient, topicMap)
 }
 
-export const publishDeviceInformation = async (modbusClient: ModbusRTU, mqttClient: MqttClient) => {
+export const publishDeviceInformation = async (modbusClient: ModbusClient, mqttClient: MqttClient) => {
     const topicMap: TopicMap = {}
 
     const deviceInformation = await getDeviceInformation(modbusClient)
@@ -86,7 +86,7 @@ export const publishDeviceInformation = async (modbusClient: ModbusRTU, mqttClie
     })
 }
 
-const publishModeSummary = async (modbusClient: ModbusRTU, mqttClient: MqttClient) => {
+const publishModeSummary = async (modbusClient: ModbusClient, mqttClient: MqttClient) => {
     // Create a map from topic name to value that should be published
     const topicMap: TopicMap = {}
 
@@ -102,7 +102,7 @@ const publishModeSummary = async (modbusClient: ModbusRTU, mqttClient: MqttClien
     await publishTopics(mqttClient, topicMap)
 }
 
-const publishSettings = async (modbusClient: ModbusRTU, mqttClient: MqttClient) => {
+const publishSettings = async (modbusClient: ModbusClient, mqttClient: MqttClient) => {
     // Create a map from topic name to value that should be published
     const topicMap: TopicMap = {}
     const settings = await getSettings(modbusClient)
@@ -142,7 +142,7 @@ export const subscribeToChanges = async (mqttClient: MqttClient) => {
 }
 
 export const handleMessage = async (
-    modbusClient: ModbusRTU,
+    modbusClient: ModbusClient,
     mqttClient: MqttClient,
     topicName: string,
     rawPayload: Buffer

--- a/eda-modbus-bridge.ts
+++ b/eda-modbus-bridge.ts
@@ -13,7 +13,9 @@ import {
 } from './app/mqtt.js'
 import { configureMqttDiscovery } from './app/homeassistant'
 import { createLogger, setLogLevel } from './app/logger'
-import { ModbusDeviceType, ModbusRtuDevice, ModbusTcpDevice, parseDevice, validateDevice } from './app/modbus'
+import { ModbusDevice, ModbusDeviceType, parseDevice, redactDevice, validateDevice } from './app/modbus'
+import { EnerventCloudClient } from './app/cloud'
+import type { ModbusClient } from './app/client'
 import { setIntervalAsync } from 'set-interval-async'
 import { ErrorHandler } from './app/error'
 
@@ -27,7 +29,7 @@ const argv = yargs(process.argv.slice(2))
     .options({
         'device': {
             description:
-                'The Modbus device to use, e.g. /dev/ttyUSB0 for Modbus RTU or tcp://192.168.1.40:502 for Modbus TCP',
+                'The Modbus device to use, e.g. /dev/ttyUSB0 for Modbus RTU, tcp://192.168.1.40:502 for Modbus TCP or cloud://123456:1234 for the Enervent cloud service',
             type: 'string',
             demandOption: true,
             alias: 'd',
@@ -94,12 +96,53 @@ const argv = yargs(process.argv.slice(2))
             alias: 'v',
         },
     })
+    // Every option can also be given as an EDA_-prefixed environment variable, e.g. EDA_DEVICE or
+    // EDA_MQTT_PASSWORD. Containers can then be configured without putting secrets on the command line.
+    .env('EDA')
     .parserConfiguration({
         // Protect against weird things happening if someone accidentally uses "-option" instead of "--option"
         'short-option-groups': false,
         'duplicate-arguments-array': false,
     })
     .parseSync()
+
+const createModbusSerialClient = (): ModbusRTU => {
+    const modbusClient = new ModbusRTU()
+    modbusClient.setID(argv.modbusSlave)
+    modbusClient.setTimeout(argv.modbusTimeout * 1000)
+
+    return modbusClient
+}
+
+const createModbusClient = async (device: ModbusDevice): Promise<ModbusClient> => {
+    switch (device.type) {
+        case ModbusDeviceType.RTU: {
+            const modbusClient = createModbusSerialClient()
+            await modbusClient.connectRTUBuffered(device.path, {
+                baudRate: 19200,
+                dataBits: 8,
+                parity: 'none',
+                stopBits: 1,
+            })
+            return modbusClient
+        }
+        case ModbusDeviceType.TCP: {
+            const modbusClient = createModbusSerialClient()
+            await modbusClient.connectTCP(device.hostname, {
+                port: device.port,
+            })
+            return modbusClient
+        }
+        case ModbusDeviceType.CLOUD: {
+            const cloudClient = new EnerventCloudClient({
+                serialNumber: device.serialNumber,
+                pin: device.pin,
+            })
+            await cloudClient.connect()
+            return cloudClient
+        }
+    }
+}
 
 void (async () => {
     // Adjust log level
@@ -109,32 +152,15 @@ void (async () => {
 
     // Create Modbus client. Abort if a malformed device is specified.
     if (!validateDevice(argv.device)) {
-        logger.error(`Malformed Modbus device ${argv.device} specified, exiting`)
+        logger.error(`Malformed Modbus device ${redactDevice(argv.device)} specified, exiting`)
         process.exit(1)
     }
     logger.info(
-        `Opening Modbus connection to ${argv.device}, slave ID ${argv.modbusSlave}, ${argv.modbusTimeout} second timeout`
+        `Opening Modbus connection to ${redactDevice(argv.device)}, slave ID ${argv.modbusSlave}, ${
+            argv.modbusTimeout
+        } second timeout`
     )
-    const modbusDevice = parseDevice(argv.device)
-    const modbusClient = new ModbusRTU()
-    modbusClient.setID(argv.modbusSlave)
-    modbusClient.setTimeout(argv.modbusTimeout * 1000)
-
-    // Use buffered RTU or TCP depending on device type
-    if (modbusDevice.type === ModbusDeviceType.RTU) {
-        const rtuDevice = modbusDevice as ModbusRtuDevice
-        await modbusClient.connectRTUBuffered(rtuDevice.path, {
-            baudRate: 19200,
-            dataBits: 8,
-            parity: 'none',
-            stopBits: 1,
-        })
-    } else if (modbusDevice.type === ModbusDeviceType.TCP) {
-        const tcpDevice = modbusDevice as ModbusTcpDevice
-        await modbusClient.connectTCP(tcpDevice.hostname, {
-            port: tcpDevice.port,
-        })
-    }
+    const modbusClient = await createModbusClient(parseDevice(argv.device))
 
     // Optionally create HTTP server
     if (argv.http) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "mqtt": "^5.3.4",
         "serialport": "^11.0.1",
         "set-interval-async": "^3.0.3",
+        "socket.io-client": "^4.8.3",
         "winston": "^3.10.0",
         "yargs": "^17.7.2"
       },
@@ -1372,6 +1373,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node14": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.2.tgz",
@@ -1593,9 +1600,10 @@
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3033,6 +3041,51 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/error-ex": {
@@ -7368,6 +7421,80 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8187,6 +8314,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {
@@ -9156,6 +9291,11 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "@tsconfig/node14": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.2.tgz",
@@ -9366,9 +9506,9 @@
       "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "requires": {
         "@types/node": "*"
       }
@@ -10312,6 +10452,38 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13322,6 +13494,56 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13867,6 +14089,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "requires": {}
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="
     },
     "y18n": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mqtt": "^5.3.4",
     "serialport": "^11.0.1",
     "set-interval-async": "^3.0.3",
+    "socket.io-client": "^4.8.3",
     "winston": "^3.10.0",
     "yargs": "^17.7.2"
   },

--- a/tests/cloud.test.ts
+++ b/tests/cloud.test.ts
@@ -1,0 +1,252 @@
+import { io } from 'socket.io-client'
+import { EnerventCloudClient } from '../app/cloud'
+import { FakeSocket } from './fakes/socketIo'
+
+jest.mock('socket.io-client', () => ({ io: jest.fn() }))
+// The handshake is chatty, and the tests run it once per case
+jest.mock('../app/logger', () => ({
+    createLogger: () => ({ debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+}))
+
+// Waits set by the client itself, mirrored here so the tests can step past them
+const DUMP_WAIT_MS = 5000
+const COIL_SETTLE_MS = 1500
+const AUTH_TIMEOUT_MS = 30000
+const CHANGES_TIMEOUT_MS = 60000
+const HEALTH_CHECK_INTERVAL_MS = 15000
+
+const DEVICE_MAC = '00:11:22:33:44:55'
+const SESSION_ID = 'session-1'
+
+// Manual boost is reported NA, which only a write succeeds against because of ACCESS_OVERRIDES
+const DEVICE_MODEL = {
+    items: [
+        { mbreg: '135', access: 'RW', symbol: 'TEMP_TARGET', bounds: '100,300' },
+        { mbreg: '50', access: 'RO', symbol: 'VENT_LEVEL_ACTUAL' },
+        { mbreg: '10001', access: 'RW', symbol: 'COIL_AWAY', bounds: '0,1' },
+        { mbreg: '10010', access: 'NA', symbol: 'COIL_M_BOOST' },
+    ],
+}
+
+const flush = (): Promise<void> => jest.advanceTimersByTimeAsync(0)
+
+const changes = (registers: number[], values: number[]) => ({
+    type: 'ucp',
+    data: { type: 'changes', registers, data: values },
+})
+
+const clients: EnerventCloudClient[] = []
+
+const newClient = (pin = '54321'): { client: EnerventCloudClient; socket: FakeSocket } => {
+    const socket = new FakeSocket()
+    ;(io as unknown as jest.Mock).mockReturnValue(socket)
+
+    const client = new EnerventCloudClient({ serialNumber: '1234567890', pin })
+    clients.push(client)
+
+    return { client, socket }
+}
+
+// The coil block is not part of the dump; the unit streams it as changes afterwards
+const connectClient = async (): Promise<{ client: EnerventCloudClient; socket: FakeSocket }> => {
+    const { client, socket } = newClient()
+    const connecting = client.connect()
+
+    socket.emit('connect')
+    await flush()
+
+    socket.receive({ _ack: socket.lastSent()._id, sessid: SESSION_ID, data: { login: 'ok', mac: DEVICE_MAC } })
+    await flush()
+
+    socket.receive({ data: { model: DEVICE_MODEL } })
+    await flush()
+
+    socket.receive({ type: 'ucp', data: { type: 'dump', registers: [6, 50, 135], data: [12, 45, 200] } })
+    await jest.advanceTimersByTimeAsync(DUMP_WAIT_MS)
+
+    socket.receive(changes([10001, 10010], [1, 0]))
+    await jest.advanceTimersByTimeAsync(COIL_SETTLE_MS)
+
+    await connecting
+
+    return { client, socket }
+}
+
+describe('EnerventCloudClient', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+    })
+
+    // Every connected client leaves a health check interval behind
+    afterEach(() => {
+        clients.splice(0).forEach((client) => client.disconnect())
+        jest.useRealTimers()
+    })
+
+    describe('connect', () => {
+        test('should log in with the configured serial number and PIN', async () => {
+            const { socket } = await connectClient()
+
+            expect(socket.sent[0]).toMatchObject({
+                type: 'backend',
+                data: { type: 'auth', cmd: 'loginWithPin', serialnumber: '1234567890', pin: '54321' },
+            })
+        })
+
+        test('should repeat the session ID and device MAC on subsequent messages', async () => {
+            const { socket } = await connectClient()
+
+            expect(socket.sent[1]).toMatchObject({
+                type: 'ucp',
+                dst: DEVICE_MAC,
+                sessid: SESSION_ID,
+                data: { command: 'model' },
+            })
+            expect(socket.sent[2]).toMatchObject({ data: { command: 'dump' } })
+        })
+
+        test('should reject when the backend refuses the login', async () => {
+            const { client, socket } = newClient('wrong')
+            const connecting = client.connect()
+
+            socket.emit('connect')
+            await flush()
+            socket.receive({ _ack: socket.lastSent()._id, data: { login: 'failed' } })
+
+            await expect(connecting).rejects.toThrow('Authentication failed')
+        })
+
+        test('should reject when the backend never answers the login', async () => {
+            const { client, socket } = newClient()
+            const connecting = client.connect()
+
+            socket.emit('connect')
+            const rejects = expect(connecting).rejects.toThrow('Authentication timeout')
+            await jest.advanceTimersByTimeAsync(AUTH_TIMEOUT_MS)
+
+            await rejects
+        })
+    })
+
+    describe('reads', () => {
+        test('should serve holding registers from the dump', async () => {
+            const { client } = await connectClient()
+
+            expect(await client.readHoldingRegisters(6, 1)).toEqual({ data: [12] })
+            expect(await client.readHoldingRegisters(50, 1)).toEqual({ data: [45] })
+        })
+
+        test('should report registers the unit never sent as zero', async () => {
+            const { client } = await connectClient()
+
+            expect(await client.readHoldingRegisters(999, 2)).toEqual({ data: [0, 0] })
+        })
+
+        test('should read coils from the 10000+ register space', async () => {
+            const { client } = await connectClient()
+
+            expect(await client.readCoils(1, 1)).toEqual({ data: [true] })
+            expect(await client.readCoils(10, 1)).toEqual({ data: [false] })
+        })
+
+        test('should only treat exactly 1 as a set coil', async () => {
+            const { client, socket } = await connectClient()
+
+            socket.receive(changes([10001], [2]))
+
+            expect(await client.readCoils(1, 1)).toEqual({ data: [false] })
+        })
+
+        test('should apply register changes pushed by the unit', async () => {
+            const { client, socket } = await connectClient()
+
+            socket.receive(changes([6, 10010], [130, 1]))
+
+            expect(await client.readHoldingRegisters(6, 1)).toEqual({ data: [130] })
+            expect(await client.readCoils(10, 1)).toEqual({ data: [true] })
+        })
+
+        test('should survive a message that is not valid JSON', async () => {
+            const { client, socket } = await connectClient()
+
+            expect(() => socket.receiveRaw('not json')).not.toThrow()
+            expect(await client.readHoldingRegisters(6, 1)).toEqual({ data: [12] })
+        })
+    })
+
+    describe('liveness', () => {
+        test('should bounce the connection when the unit stops sending changes', async () => {
+            const { socket } = await connectClient()
+
+            await jest.advanceTimersByTimeAsync(CHANGES_TIMEOUT_MS + HEALTH_CHECK_INTERVAL_MS)
+
+            expect(socket.reconnects).toEqual(1)
+        })
+
+        test('should leave the connection alone while changes keep arriving', async () => {
+            const { socket } = await connectClient()
+
+            await jest.advanceTimersByTimeAsync(CHANGES_TIMEOUT_MS - HEALTH_CHECK_INTERVAL_MS)
+            socket.receive(changes([6], [130]))
+            await jest.advanceTimersByTimeAsync(CHANGES_TIMEOUT_MS - HEALTH_CHECK_INTERVAL_MS)
+
+            expect(socket.reconnects).toEqual(0)
+        })
+
+        test('should log in again when the socket reconnects', async () => {
+            const { socket } = await connectClient()
+            const sentBefore = socket.sent.length
+
+            socket.emit('connect')
+            await flush()
+
+            expect(socket.sent[sentBefore]).toMatchObject({ data: { cmd: 'loginWithPin' } })
+        })
+    })
+
+    describe('writes', () => {
+        test('should send the write and resolve once the unit echoes the new value back', async () => {
+            const { client, socket } = await connectClient()
+
+            const writing = client.writeRegister(135, 210)
+            await flush()
+
+            expect(socket.lastSent()).toMatchObject({
+                type: 'ucp',
+                dst: DEVICE_MAC,
+                data: { type: 'command', command: 'write', id: 135, value: 210 },
+            })
+
+            socket.receive(changes([135], [210]))
+            await writing
+
+            expect(await client.readHoldingRegisters(135, 1)).toEqual({ data: [210] })
+        })
+
+        test('should write coils to the 10000+ register space', async () => {
+            const { client, socket } = await connectClient()
+
+            const writing = client.writeCoil(10, true)
+            await flush()
+
+            expect(socket.lastSent()).toMatchObject({ data: { command: 'write', id: 10010, value: 1 } })
+
+            socket.receive(changes([10010], [1]))
+            await writing
+        })
+
+        test.each([
+            ['a register the device model does not describe', 999, 1],
+            ['a register the device reports as read-only', 50, 60],
+            ['a value outside the bounds the device reports', 135, 400],
+            ['a value the register already holds', 135, 200],
+        ])('should not send a write for %s', async (_reason, register, value) => {
+            const { client, socket } = await connectClient()
+            const sentBefore = socket.sent.length
+
+            await client.writeRegister(register, value)
+
+            expect(socket.sent).toHaveLength(sentBefore)
+        })
+    })
+})

--- a/tests/fakes/modbusClient.ts
+++ b/tests/fakes/modbusClient.ts
@@ -1,0 +1,53 @@
+import type { CoilResult, ModbusClient, RegisterResult } from '../../app/client'
+
+// Unseeded addresses read as 0/false, so fixtures only define what a test asserts on
+export class FakeModbusClient implements ModbusClient {
+    readonly registerReads: [number, number][] = []
+    readonly coilReads: [number, number][] = []
+    readonly registerWrites: [number, number][] = []
+    readonly coilWrites: [number, boolean][] = []
+
+    private readonly registers: Record<number, number>
+    private readonly coils: Record<number, boolean>
+
+    constructor(registers: Record<number, number> = {}, coils: Record<number, boolean> = {}) {
+        this.registers = { ...registers }
+        this.coils = { ...coils }
+    }
+
+    readCoils(dataAddress: number, length: number): Promise<CoilResult> {
+        this.coilReads.push([dataAddress, length])
+
+        const data: boolean[] = []
+        for (let i = 0; i < length; i++) {
+            data.push(this.coils[dataAddress + i] ?? false)
+        }
+
+        return Promise.resolve({ data })
+    }
+
+    writeCoil(dataAddress: number, state: boolean): Promise<void> {
+        this.coilWrites.push([dataAddress, state])
+        this.coils[dataAddress] = state
+
+        return Promise.resolve()
+    }
+
+    readHoldingRegisters(dataAddress: number, length: number): Promise<RegisterResult> {
+        this.registerReads.push([dataAddress, length])
+
+        const data: number[] = []
+        for (let i = 0; i < length; i++) {
+            data.push(this.registers[dataAddress + i] ?? 0)
+        }
+
+        return Promise.resolve({ data })
+    }
+
+    writeRegister(dataAddress: number, value: number): Promise<void> {
+        this.registerWrites.push([dataAddress, value])
+        this.registers[dataAddress] = value
+
+        return Promise.resolve()
+    }
+}

--- a/tests/fakes/socketIo.ts
+++ b/tests/fakes/socketIo.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'events'
+
+export type SentMessage = {
+    _id?: number
+    type?: string
+    dst?: string
+    sessid?: string
+    data?: {
+        type?: string
+        cmd?: string
+        command?: string
+        serialnumber?: string
+        pin?: string
+        id?: number
+        value?: number
+    }
+}
+
+// The backend talks in JSON strings carried on the "message" event, not in objects
+export class FakeSocket extends EventEmitter {
+    readonly sent: SentMessage[] = []
+    readonly io = new EventEmitter()
+
+    disconnected = false
+    reconnects = 0
+
+    send(message: string): void {
+        this.sent.push(JSON.parse(message) as SentMessage)
+    }
+
+    onAny(): void {
+        // The client only logs events it doesn't handle
+    }
+
+    // The client bounces a stale connection with socket.disconnect().connect()
+    disconnect(): this {
+        this.disconnected = true
+
+        return this
+    }
+
+    connect(): this {
+        this.disconnected = false
+        this.reconnects++
+
+        return this
+    }
+
+    receive(payload: unknown): void {
+        this.emit('message', JSON.stringify(payload))
+    }
+
+    receiveRaw(message: string): void {
+        this.emit('message', message)
+    }
+
+    lastSent(): SentMessage {
+        return this.sent[this.sent.length - 1]
+    }
+}

--- a/tests/modbus.test.ts
+++ b/tests/modbus.test.ts
@@ -1,11 +1,45 @@
-import { validateDevice, parseDevice, ModbusDeviceType, setSetting } from '../app/modbus'
-import ModbusRTU from 'modbus-serial'
+import {
+    acknowledgeAlarm,
+    getAlarmSummary,
+    getDeviceInformation,
+    getDeviceState,
+    getMode,
+    getModeSummary,
+    getNewestAlarm,
+    getReadings,
+    getSettings,
+    ModbusDeviceType,
+    parseDevice,
+    redactDevice,
+    resetDeviceInformationCache,
+    setMode,
+    setSetting,
+    validateDevice,
+} from '../app/modbus'
+import type { ModbusClient } from '../app/client'
+import { FakeModbusClient } from './fakes/modbusClient'
+import { AutomationType, HeatingType } from '../app/enervent'
 
 test('validateDevice', () => {
     expect(validateDevice('/dev/ttyUSB0')).toEqual(true)
     expect(validateDevice('dev/ttyUSB0')).toEqual(false)
     expect(validateDevice('tcp://192.168.1.40:502')).toEqual(true)
     expect(validateDevice('192.168.1.40:502')).toEqual(false)
+    expect(validateDevice('cloud://1234567890:54321')).toEqual(true)
+    expect(validateDevice('1234567890:54321')).toEqual(false)
+    // Without a PIN the device would only fail later, as a login the backend rejects
+    expect(validateDevice('cloud://1234567890')).toEqual(false)
+    expect(validateDevice('cloud://1234567890:')).toEqual(false)
+    expect(validateDevice('cloud://:54321')).toEqual(false)
+    expect(validateDevice('cloud://')).toEqual(false)
+})
+
+test('redactDevice', () => {
+    // The PIN must never reach the logs, the serial number is fine
+    expect(redactDevice('cloud://1234567890:54321')).toEqual('cloud://1234567890:<redacted>')
+    // Non-cloud devices carry no secret and are left alone
+    expect(redactDevice('/dev/ttyUSB0')).toEqual('/dev/ttyUSB0')
+    expect(redactDevice('tcp://192.168.1.40:502')).toEqual('tcp://192.168.1.40:502')
 })
 
 test('parseDevice', () => {
@@ -23,16 +57,23 @@ test('parseDevice', () => {
         hostname: '127.0.0.1',
         port: 502,
     })
+    expect(parseDevice('cloud://1234567890:54321')).toEqual({
+        type: ModbusDeviceType.CLOUD,
+        serialNumber: '1234567890',
+        pin: '54321',
+    })
 })
 
 describe('setSetting', () => {
-    let mockClient: ModbusRTU
+    let mockClient: ModbusClient
 
     beforeEach(() => {
         mockClient = {
-            writeRegister: jest.fn().mockResolvedValue(undefined),
+            readCoils: jest.fn().mockResolvedValue({ data: [] }),
             writeCoil: jest.fn().mockResolvedValue(undefined),
-        } as any
+            readHoldingRegisters: jest.fn().mockResolvedValue({ data: [] }),
+            writeRegister: jest.fn().mockResolvedValue(undefined),
+        }
     })
 
     describe('holding register settings (numeric)', () => {
@@ -126,6 +167,326 @@ describe('setSetting', () => {
             await expect(setSetting(mockClient, 'nonExistentSetting', '123')).rejects.toThrow(
                 'Unknown setting "nonExistentSetting"'
             )
+        })
+    })
+})
+
+describe('device operations', () => {
+    // A Pingvin with EDA automation, DC fans, CW cooling and EDE heating
+    const DEVICE_REGISTERS = {
+        154: 1, // cooling type, CW
+        171: 3, // heating type, EDE/MDE
+        596: 0,
+        597: 0, // device family, Pingvin
+        598: 12345, // serial number
+        599: 217, // software version 2.17, i.e. EDA automation
+        640: 1, // Modbus address
+    }
+    const DEVICE_COILS = {
+        16: true, // EC (DC) fans
+    }
+    // MD automation unlocks eco mode and the fan speed readings
+    const MD_AUTOMATION = { 599: 176 }
+
+    const device = (registers: Record<number, number> = {}, coils: Record<number, boolean> = {}) =>
+        new FakeModbusClient({ ...DEVICE_REGISTERS, ...registers }, { ...DEVICE_COILS, ...coils })
+
+    beforeEach(() => resetDeviceInformationCache())
+
+    describe('getDeviceInformation', () => {
+        test('should describe the unit', async () => {
+            const client = device()
+
+            expect(await getDeviceInformation(client)).toEqual({
+                softwareVersion: 2.17,
+                automationType: AutomationType.EDA,
+                fanType: 'EC',
+                coolingTypeInstalled: 'CW',
+                heatingTypeInstalled: HeatingType.EDE,
+                modelType: 'Pingvin',
+                modelName: 'Pingvin eco EDE/MDE - CW',
+                serialNumber: 12345,
+                modbusAddress: 1,
+            })
+        })
+
+        test('should report AC fans when the motor type coil is off', async () => {
+            const client = device({}, { 16: false })
+
+            expect((await getDeviceInformation(client)).fanType).toEqual('AC')
+        })
+
+        test('should refuse to identify a device that reports no software version', async () => {
+            await expect(getDeviceInformation(new FakeModbusClient())).rejects.toThrow('refusing to identify it')
+            // Nothing bogus was cached, a working device still identifies
+            expect(await getDeviceInformation(device())).toMatchObject({ modelType: 'Pingvin' })
+        })
+
+        test('should only read the device once', async () => {
+            const client = device()
+
+            await getDeviceInformation(client)
+            const readsAfterFirstCall = client.registerReads.length
+            await getDeviceInformation(client)
+
+            expect(client.registerReads.length).toEqual(readsAfterFirstCall)
+        })
+    })
+
+    describe('getModeSummary', () => {
+        test('should report the state of each mode coil', async () => {
+            const client = device(
+                {},
+                {
+                    3: true, // overPressure
+                    10: true, // manualBoost
+                }
+            )
+
+            expect(await getModeSummary(client)).toEqual({
+                away: false,
+                longAway: false,
+                overPressure: true,
+                maxHeating: false,
+                maxCooling: false,
+                manualBoost: true,
+            })
+        })
+
+        test('should include eco on MD automation only', async () => {
+            const client = device(MD_AUTOMATION, { 40: true })
+
+            expect(await getModeSummary(client)).toMatchObject({ eco: true })
+        })
+    })
+
+    describe('getMode', () => {
+        test('should read the coil belonging to the mode', async () => {
+            const client = device({}, { 2: true })
+
+            expect(await getMode(client, 'longAway')).toEqual(true)
+            expect(client.coilReads).toContainEqual([2, 1])
+        })
+
+        test('should reject unknown modes', async () => {
+            await expect(getMode(new FakeModbusClient(), 'nonExistentMode')).rejects.toThrow('Unknown mode')
+        })
+    })
+
+    describe('setMode', () => {
+        test('should disable the other modes when enabling one', async () => {
+            const client = device()
+
+            await setMode(client, 'away', true)
+
+            expect(client.coilWrites).toEqual([
+                [1, true],
+                [2, false],
+                [3, false],
+                [6, false],
+                [7, false],
+                [10, false],
+            ])
+        })
+
+        test('should leave the other modes alone when disabling one', async () => {
+            const client = device()
+
+            await setMode(client, 'away', false)
+
+            expect(client.coilWrites).toEqual([[1, false]])
+        })
+
+        test('should reject unknown modes', async () => {
+            await expect(setMode(new FakeModbusClient(), 'nonExistentMode', true)).rejects.toThrow('Unknown mode')
+        })
+    })
+
+    describe('getReadings', () => {
+        const READING_REGISTERS = {
+            6: 12, // fresh air 1.2
+            7: 180, // supply air after heat recovery 18.0
+            8: 205, // supply air 20.5
+            9: 45, // waste air 4.5
+            10: 210, // exhaust air 21.0
+            11: 215, // exhaust air before heat recovery 21.5
+            13: 42, // exhaust air humidity
+            29: 80, // heat recovery supply side
+            30: 75, // heat recovery exhaust side
+            31: 100, // heat recovery temperature difference supply side 10.0
+            32: 90, // heat recovery temperature difference exhaust side 9.0
+            35: 38, // 48 hour mean exhaust humidity
+            45: 4, // temperature control state, heating
+            46: 220, // room temperature average 22.0
+            47: 205, // cascade Sp
+            48: 10, // cascade P
+            49: 5, // cascade I
+            50: 45, // ventilation level actual
+            53: 50, // ventilation level target
+            56: 120, // over pressure time left
+        }
+
+        test('should read every sensor', async () => {
+            const client = device(READING_REGISTERS)
+
+            expect(await getReadings(client)).toEqual({
+                freshAirTemperature: 1.2,
+                supplyAirTemperatureAfterHeatRecovery: 18,
+                supplyAirTemperature: 20.5,
+                wasteAirTemperature: 4.5,
+                exhaustAirTemperature: 21,
+                exhaustAirHumidity: 42,
+                heatRecoverySupplySide: 80,
+                heatRecoveryExhaustSide: 75,
+                heatRecoveryTemperatureDifferenceSupplySide: 10,
+                heatRecoveryTemperatureDifferenceExhaustSide: 9,
+                mean48HourExhaustHumidity: 38,
+                temperatureControlState: 'HEATING',
+                cascadeSp: 205,
+                cascadeP: 10,
+                cascadeI: 5,
+                overPressureTimeLeft: 120,
+                ventilationLevelActual: 45,
+                ventilationLevelTarget: 50,
+                roomTemperatureAvg: 22,
+                exhaustAirTemperatureBeforeHeatRecovery: 21.5,
+            })
+        })
+
+        test('should report the return water temperature on EDW units instead', async () => {
+            const client = device({ ...READING_REGISTERS, 171: 1, 12: 300 })
+            const readings = await getReadings(client)
+
+            expect(readings).toMatchObject({ returnWaterTemperature: 30 })
+            expect(readings).not.toHaveProperty('exhaustAirTemperatureBeforeHeatRecovery')
+        })
+
+        test('should include the control panel and fan speed readings on MD automation', async () => {
+            const client = device({ ...MD_AUTOMATION, ...READING_REGISTERS, 1: 215, 2: 220, 3: 1500, 4: 1400 })
+
+            expect(await getReadings(client)).toMatchObject({
+                controlPanel1Temperature: 21.5,
+                controlPanel2Temperature: 22,
+                supplyFanSpeed: 1500,
+                exhaustFanSpeed: 1400,
+            })
+        })
+
+        test('should include configured analog sensors', async () => {
+            const client = device({ ...READING_REGISTERS, 104: 1, 23: 450 })
+
+            expect(await getReadings(client)).toMatchObject({ analogInputCo21: 450 })
+        })
+    })
+
+    describe('getSettings', () => {
+        const SETTING_REGISTERS = {
+            54: 80, // supply fan over pressure
+            55: 70, // exhaust fan over pressure
+            57: 30, // over pressure delay
+            100: 50, // away ventilation level
+            101: 20, // away temperature reduction 2.0
+            102: 40, // long away ventilation level
+            103: 30, // long away temperature reduction 3.0
+            135: 210, // temperature target 21.0
+            136: 1, // temperature control mode
+        }
+        const SETTING_COILS = {
+            12: false, // summer night cooling allowed
+            18: true, // away heating allowed
+            19: false, // away cooling allowed
+            20: true, // long away heating allowed
+            21: false, // long away cooling allowed
+            52: true, // cooling allowed
+            54: true, // heating allowed
+            55: true, // defrosting allowed
+        }
+
+        test('should read every setting', async () => {
+            const client = device(SETTING_REGISTERS, SETTING_COILS)
+
+            expect(await getSettings(client)).toEqual({
+                overPressureDelay: 30,
+                awayVentilationLevel: 50,
+                awayTemperatureReduction: 2,
+                longAwayVentilationLevel: 40,
+                longAwayTemperatureReduction: 3,
+                temperatureTarget: 21,
+                temperatureControlMode: 1,
+                coolingAllowed: true,
+                heatingAllowed: true,
+                awayCoolingAllowed: false,
+                awayHeatingAllowed: true,
+                longAwayCoolingAllowed: false,
+                longAwayHeatingAllowed: true,
+                defrostingAllowed: true,
+                summerNightCoolingAllowed: false,
+                supplyFanOverPressure: 80,
+                exhaustFanOverPressure: 70,
+            })
+        })
+
+        test('should skip the heating and cooling permissions on legacy EDA units', async () => {
+            const client = device({ ...SETTING_REGISTERS, 599: 201 }, SETTING_COILS)
+            const settings = await getSettings(client)
+
+            expect(settings).not.toHaveProperty('coolingAllowed')
+            expect(settings).not.toHaveProperty('awayHeatingAllowed')
+        })
+
+        test('should include eco on MD automation', async () => {
+            const client = device({ ...MD_AUTOMATION, ...SETTING_REGISTERS }, { ...SETTING_COILS, 40: true })
+
+            expect(await getSettings(client)).toMatchObject({ eco: true })
+        })
+    })
+
+    describe('getDeviceState', () => {
+        test('should parse the state bit field', async () => {
+            const client = new FakeModbusClient({ 44: 16 })
+
+            expect(await getDeviceState(client)).toMatchObject({ normal: false, away: true, stop: false })
+            expect(client.registerReads).toContainEqual([44, 1])
+        })
+    })
+
+    describe('alarms', () => {
+        // A heat pump alarm, active, raised 2024-11-05 14:30
+        const ALARM_REGISTERS = { 385: 7, 386: 2, 387: 24, 388: 11, 389: 5, 390: 14, 391: 30 }
+
+        test('getNewestAlarm should describe the alarm and when it was raised', async () => {
+            const client = device(ALARM_REGISTERS)
+
+            expect(await getNewestAlarm(client)).toEqual({
+                name: 'HPError',
+                description: 'Heatpump',
+                type: 7,
+                state: 2,
+                timestamp: new Date(2024, 10, 5, 14, 30),
+            })
+        })
+
+        test('getNewestAlarm should return null for an unknown alarm type', async () => {
+            const client = device({ ...ALARM_REGISTERS, 385: 9999 })
+
+            expect(await getNewestAlarm(client)).toBeNull()
+        })
+
+        test('getAlarmSummary should only mark the active alarm', async () => {
+            const client = device(ALARM_REGISTERS)
+            const summary = await getAlarmSummary(client)
+
+            expect(summary.filter((alarm) => alarm.state !== 0)).toEqual([
+                { name: 'HPError', description: 'Heatpump', type: 7, state: 2 },
+            ])
+        })
+
+        test('acknowledgeAlarm should write the acknowledgement register', async () => {
+            const client = device()
+
+            await acknowledgeAlarm(client)
+
+            expect(client.registerWrites).toEqual([[386, 1]])
         })
     })
 })


### PR DESCRIPTION
Hi,

Thanks for the work on this modbus bridge, it kinda was the missing piece in my puzzle.

I had been experimenting with reverse engineering how the Enervent "cloud" interface to my ventilation unit worked a few years ago and got something working back then, never really got anything really done related to it but it clarified how things were implemented.

Now i stumbled upon your project when I once again was thinking it would be nice to get a bit visibility to my unit. Was not really that eager to add any additional devices or flash the firmware to allow TCP connections so that was the motivation to combine the client for communicating with the device via the Enervent "cloud".

Now with the help of AI it was pretty trivial to implement the idea and now i've been running this with my home assistant setup for a while without bigger issues.

I have no idea if this is allowed or supported and totally fine if you don't want to include this on the upstream.